### PR TITLE
Fixing https://jira2.palm.com/browse/GF-2036 kunmyon choi

### DIFF
--- a/kind.Spotlight.Util.js
+++ b/kind.Spotlight.Util.js
@@ -59,12 +59,10 @@ enyo.kind({
 			if (oNode.offsetParent) {
 				do {
 					// Fix for FF (GF-2036), offsetParent is working differently between FF and chrome 
-					if(enyo.platform.firefox) {					
+					if (enyo.platform.firefox) {					
 						oLeft += oNode.offsetLeft;
 						oTop  += oNode.offsetTop;
-					}
-					else
-					{
+					} else {
 						oLeft += oNode.offsetLeft - (oNode.offsetParent ? oNode.offsetParent.scrollLeft : 0);
 						oTop  += oNode.offsetTop  - (oNode.offsetParent ? oNode.offsetParent.scrollTop  : 0);	
 					}


### PR DESCRIPTION
Browser native function (offsetParent) is working differently between FF and chrome.
1. offsetParent of list item is app_listPanel_scroller_strategy_client (has scrollTop value) in FF.
2. offsetParent of list item is app_listPanel_scroller in chrome.

I did temporary bug fix for browser incompatibility. 
