### PR TITLE
Fixing https://jira2.palm.com/browse/GF-2854

### DIFF
--- a/decorators/kind.Spotlight.Decorator.GridList.js
+++ b/decorators/kind.Spotlight.Decorator.GridList.js
@@ -102,7 +102,7 @@ enyo.kind({
 			var nCurrent = this._getCurrent(oSender);
 			if (nCurrent === null) { return true; }
 			var nNew = nCurrent - oSender.itemsPerRow;
-			if (nNew > 0) {
+			if (nNew >= 0) {
 				this._setCurrent(oSender, nNew, true);
 				return true;
 			}


### PR DESCRIPTION
Grid item index starts with 0
So, modified kind.Spotlight.Decorator.GridList.js to accept 0 index when up key is given.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi kunmyon.choi@lge.com
