### PR TITLE
Fixing spotlight infinite loop bug on moon.Panels

### DIFF
--- a/decorators/kind.Spotlight.Decorator.Container.js
+++ b/decorators/kind.Spotlight.Decorator.Container.js
@@ -52,7 +52,19 @@ enyo.kind({
 			}
 			enyo.Spotlight.Util.dispatchEvent('onSpotlightContainerEnter', {}, oSender);
 		},
-				
+
+		_getInstanceOfPanels: function(oChild) {
+			if (!oChild)  { return null; }
+
+			while (oChild.parent) {
+				oChild = oChild.parent;
+				if (oChild instanceof enyo.Panels) {
+					return oChild;
+				}
+			}
+			return null;
+		},
+		
 		/******************************/
 		
 		onSpotlightFocused: function(oSender, oEvent) {
@@ -61,11 +73,12 @@ enyo.kind({
 			this._initComponent(oSender);
 			
 			if (this._hadFocus(oSender)) {												// Focus came from within
-				var s5WayEventType = enyo.Spotlight.getLast5WayEvent() ? enyo.Spotlight.getLast5WayEvent().type : '';
-				if (!(oSender.parent instanceof enyo.Panels)) {
+				var s5WayEventType = enyo.Spotlight.getLast5WayEvent() ? enyo.Spotlight.getLast5WayEvent().type : '',
+					panels = this._getInstanceOfPanels(oSender);
+				if (panels === null) {
 					enyo.Spotlight.Util.dispatchEvent(s5WayEventType, null, oSender);
 				} else 
-				if (oSender.parent.spotlight !== true && oSender.parent.spotlight != 'true') {
+				if (panels.spotlight !== true && panels.spotlight != 'true') {
 					enyo.Spotlight.Util.dispatchEvent(s5WayEventType, null, oSender);
 				}
 				this._focusLeave(oSender, s5WayEventType);


### PR DESCRIPTION
- Fixing onSpotlightFocused of kind.spotlight.decorator.container.js to get proper parent of panel for the alwaysviewing pattern panels case.
- You can test this with AlwaysViewingPanelsSample.html in https://github.com/enyojs/moonstone/pull/236 pull request (http://jira2.lgsvl.com/browse/GF-7532, http://jira2.lgsvl.com/browse/GF-4041)

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)
