### PR TITLE
GF-9997: Send the "onSpotlightKeyUp" event by force

### DIFF
--- a/kind.Spotlight.js
+++ b/kind.Spotlight.js
@@ -65,6 +65,9 @@ enyo.kind({
 			if (this._oCurrent === oControl) {
 				return true;
 			}
+			if (this._oCurrent !== null) {
+				this._dispatchEvent('onSpotlightKeyUp');
+			}
 			this._oCurrent = oControl;
 			// console.log('CURRENT: ', oControl.name, oControl.kindName);
 			enyo.Signals.send('onSpotlightCurrentChanged', {current: oControl});


### PR DESCRIPTION
Send the "onSpotlightKeyUp" event to the previous widget by force
because this._oCurrent will be changed and the previous widget can't get
that event

http://jira2.lgsvl.com/browse/GF-9997

Enyo-DCO-1.1-Signed-Off-By: Yunbum Sung yb.sung@lge.com
