### PR TITLE
GF-33973: Use enyo.master as root of event chain, since this is more rel...

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -31,9 +31,8 @@ enyo.Spotlight = new function() {
 		
 		
 	var _initialize = function() {
-			_oRoot = enyo.roots[0];
+			_oRoot = enyo.master;
 			_interceptEvents();
-			_oThis.spot(_oRoot);
 		},
 		
 		// Event hook to the owner to catch Spotlight Events
@@ -229,6 +228,13 @@ enyo.Spotlight = new function() {
 				//enyo.log('Dummy funciton');
 			};
 		};
+
+		// Special case code for bootstrapping 5-way navigation - can't dispatch Spotlight
+		// key events until we have a spotted a child at least once, so we do it here
+		if (!this.getCurrent() && enyo.roots && enyo.roots[0]) {
+			enyo.Spotlight.spot(enyo.roots[0]);
+			return;
+		}
 
 		switch (oEvent.type) {
 			case 'keydown'  : return _dispatchEvent('onSpotlightKeyDown', oEvent);


### PR DESCRIPTION
...iable than enyo.roots, which doesn't get populated until the app view renders.  Also remove default initial spotlight, and add code for bootstrapping 5-way using enyo.roots if available.

Signed-Off-By: Kevin Schaaf (kevin.schaaf@lge.com)
