### PR TITLE
Run __initialize()_ on load, not at enyo.ready(). Fixes race condition i...

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -541,9 +541,7 @@ enyo.Spotlight = new function() {
 	this.unmute  = function(oSender) { enyo.Spotlight.Muter.removeMuteReason(oSender); }
 	this.isMuted = function()        { return enyo.Spotlight.Muter.isMuted(); }
 	
-	enyo.ready(function() {
-		_initialize();
-	});
+	_initialize();
 };
 
 // Event hook to all system events to catch KEYPRESS and Mouse Events


### PR DESCRIPTION
...n which _render()_ is called before Spotlight is initialized.

Enyo-DCO-1.1-Signed-off-by: Chris Patalano christopher.patalano@lge.com
