### PR TITLE
GF-36626: Address spotlight issues encountered while debugging ListActio...

### DIFF
--- a/enyo.Spotlight.NearestNeighbor.js
+++ b/enyo.Spotlight.NearestNeighbor.js
@@ -6,10 +6,10 @@
 enyo.Spotlight.NearestNeighbor = new function() {
 	var _isInHalfPlane = function(sDirection, oBounds1, oBounds2) {
 			switch (sDirection) {
-				case 'UP'    : return oBounds1.top  >= oBounds2.top    +  oBounds2.height;
-				case 'DOWN'  : return oBounds1.top  +  oBounds1.height <= oBounds2.top;
-				case 'LEFT'  : return oBounds1.left >= oBounds2.left   +  oBounds2.width;
-				case 'RIGHT' : return oBounds1.left +  oBounds1.width  <= oBounds2.left;
+				case 'UP'    : return oBounds1.top  >= oBounds2.top    +  oBounds2.height - 1;
+				case 'DOWN'  : return oBounds1.top  +  oBounds1.height - 1 <= oBounds2.top;
+				case 'LEFT'  : return oBounds1.left >= oBounds2.left   +  oBounds2.width - 1;
+				case 'RIGHT' : return oBounds1.left +  oBounds1.width - 1 <= oBounds2.left;
 			}
 		},
 

--- a/enyo.Spotlight.Util.js
+++ b/enyo.Spotlight.Util.js
@@ -19,10 +19,11 @@ enyo.Spotlight.Util = new function() {
 		var f = oControl.dispatchEvent;
 
 		oControl.dispatchEvent = function(sEventName, oEvent, oEventSender) {
-			if (fHandler(oControl, oEvent)) {                                       // If handler returns true - prevent default
+			if (!oEvent.delegate && fHandler(oControl, oEvent)) {                   // If handler returns true - prevent default
 				oEvent.type = null;
+				return true;
 			} else {
-				f.apply(oControl, [sEventName, oEvent, oEventSender]);              // If handler returns false - call original dispatcher and allow bubbling
+				return f.apply(oControl, [sEventName, oEvent, oEventSender]);       // If handler returns false - call original dispatcher and allow bubbling
 			}
 		};
 	},

--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -42,7 +42,9 @@ enyo.Spotlight = new function() {
 				if (_oThis.rootDispatchFunction.apply(_oRoot, [sEventName, oEvent, oSender])) {
 					return true;
 				}
-				return _oThis.onSpotlightEvent(oEvent);
+				if (!oEvent.delegate) {
+					return _oThis.onSpotlightEvent(oEvent);
+				}
 			};
 		},
 		
@@ -100,7 +102,7 @@ enyo.Spotlight = new function() {
 				_oThis.spot(oControl, sDirection);
 			} else {
 				var oParent = _oThis.getParent();
-				if (typeof oParent.spotlight == 'undefined') {  // Reached the end of spottable world
+				if (typeof oParent.spotlight == 'undefined' || oParent.spotlightModal) {  // Reached the end of spottable world
 					_oThis.spot(_oLastSpotlightTrueControl);
 				} else {
 					_oThis.spot(_oThis.getParent(), sDirection);


### PR DESCRIPTION
...ns oddities.
- Allow 1px of overlap for determining half-plane siblings.  This accounts for rounding errors that can occur when items are sized using percentages (adjacent item bounds can show them to overlap by 1px).
- Avoid intercepting calls to dispatchEvent for events with a delegate.  This is required due to a change that occurred in Enyo core that commonized the bubble path for events and delegated event handlers; since both come through dispatchEvent, we need to filter based on inEvent.delegate.
- Add handy spotlightModal flag, which allows 5-way focus to be captured inside of a parent.  Greatly reduces code required to do that using standard events.

Signed-Off-By: Kevin Schaaf (kevin.schaaf@lge.com)
