### PR TITLE
Fixing abnormal focus jump when magic remote is hided by timeout.

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -215,6 +215,8 @@ enyo.Spotlight = new function() {
 					return enyo.Spotlight.Scrolling.processMouseWheel(oEvent, this.onScroll, this);
 				case 'keydown':
 				case 'keyup':
+					// Filter out special keycode from Input Manager for magic remote show/hide
+					if (oEvent.keyCode === 0 && (oEvent.keyIdentifier === "U+1200202" || oEvent.keyIdentifier === "U+1200201")) {return true;}
 					return enyo.Spotlight.Accelerator.processKey(oEvent, this.onAcceleratedKey, this);
 			}
 		}


### PR DESCRIPTION
- Filter out special key events for magic remote show/hide. 
- Fixing   http://jira2.lgsvl.com/browse/GF-36452, http://jira2.lgsvl.com/browse/GF-38105

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)
