### PR TITLE
Last focus issue fix

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -187,7 +187,7 @@ enyo.Spotlight = new function() {
 		_comeBackFromPointerMode = function() {
 			if (!_bCanFocus) {  // Comming back from pointer mode, show control once before continuing navigation
 				_bCanFocus = true;
-				_oThis.spot(_oLastSpotlightTrueControl5Way);
+				_oThis.spot(_oCurrent);
 				return true;
 			}
 			return false;


### PR DESCRIPTION
When user rollover specific component using by pointer, the component
means last focus. But user get back to remocon, focus move to last 5 way
history(rollover history using by pointer is not applied).
Enyo-DCO-1.1-Signed-off-by: Changgi Lee changgi.lee@lge.com
