### PR TITLE
Partially Fixing http://jira2.lgsvl.com/browse/GF-40445

### DIFF
--- a/enyo.Spotlight.Util.js
+++ b/enyo.Spotlight.Util.js
@@ -11,7 +11,7 @@ enyo.Spotlight.Util = new function() {
 			if (sEvent == 'onSpotlightBlur' || sEvent == 'onSpotlightPoint') { return; }
 			oControl = enyo.Spotlight.getCurrent();
 		}
-
+		
 		oData            = oData ? enyo.clone(oData) : {};
 		oData.type       = sEvent;
 		oData.originator = oControl;
@@ -47,6 +47,10 @@ enyo.Spotlight.Util = new function() {
 	};
 
 	this.getAbsoluteBounds = function(oControl) {
+		
+		var bHidden = !oControl.getShowing();
+		if (bHidden) { oControl.setShowing(true); }
+		
 		var oLeft           = 0,
 			oTop            = 0,
 			oMatch          = null,
@@ -79,6 +83,9 @@ enyo.Spotlight.Util = new function() {
 				}
 			} while ((oNode = oNode.offsetParent));
 		}
+		
+		if (bHidden) { oControl.setShowing(false); }
+		
 		return {
 			top     : oTop,
 			left    : oLeft,


### PR DESCRIPTION
This allows bounds to be non-zero for hidden controls, thus allowing spot to be transferred to siblings in 5way mode.
This only partially fixes the issue of spot being present on screen at all times, which for now will involve application setting it explicitly.
