### PR TITLE
Fixing http://jira2.lgsvl.com/browse/GF-40254

### DIFF
--- a/enyo.Spotlight.Scrolling.js
+++ b/enyo.Spotlight.Scrolling.js
@@ -17,16 +17,13 @@ enyo.Spotlight.Scrolling = new function() {
 
 	this.processMouseWheel = function(oEvent, fCallback, oContext) {
 		_nDelta += oEvent.wheelDeltaY;
-		var bUp = true;
 
 		if (_nDelta >= this.frequency) {
 			_nDelta = 0;
+			return fCallback.apply(oContext, [oEvent, true]);
 		} else if (_nDelta <= -this.frequency) {
 			_nDelta = 0;
-			bUp = false;
+			return fCallback.apply(oContext, [oEvent, false]);
 		}
-		
-		return fCallback.apply(oContext, [oEvent, bUp]);
-
 	};
 };


### PR DESCRIPTION
Old code was preventing default mousewheel events in case that no spottable items are in the app. This will become irrelevant when we push new spotlight-init branch, which will ensure thowing Exception if nothing is spottable.

Such are the benefits of code becoming more finite-state.
