### PR TITLE
A mix of spotlight fixes addressed while tackling various issues:

### DIFF
--- a/decorators/kind.Spotlight.Decorator.Container.js
+++ b/decorators/kind.Spotlight.Decorator.Container.js
@@ -50,7 +50,7 @@ enyo.kind({
 		// Was last spotted control the container's child?
 		_hadFocus: function(oSender) {
 			var oLastControl = enyo.Spotlight.getLastControl();
-			if (!oSender._spotlight.bEnorceOutsideIn) { return false; }  // Programmatically sptted containers are always treated as not having focus
+			if (oSender._spotlight.bEnorceOutsideIn) { return false; }  // Programmatically sptted containers are always treated as not having focus
 			if (!enyo.Spotlight.isSpottable(oLastControl)) { return false; } // Because oLastControl might have been DHD'd
 			return enyo.Spotlight.Util.isChild(oSender, oLastControl);
 		},

--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -274,9 +274,12 @@ enyo.Spotlight = new function() {
 							this.setPointerMode(true);
 							return true; 
 						case 1537: 
-							// Pointer hidden event; set pointer mode false and spot last 5-way control
+							// Pointer hidden event; set pointer mode false
 							this.setPointerMode(false);
-							_oThis.spot(_oLast5WayControl);
+							// Spot last 5-way control, only if there's not already focus on screen
+							if (!_oLastMouseMoveTarget) {
+								_oThis.spot(_oLast5WayControl);
+							}
 							return true; 
 					}
 					enyo.Spotlight.Accelerator.processKey(oEvent, this.onAcceleratedKey, this);
@@ -419,7 +422,8 @@ enyo.Spotlight = new function() {
 		if (_isArrowKey(oEvent.keyCode)) {
 			var bWasPointerMode = this.getPointerMode();
 			this.setPointerMode(false);  // Preserving explicit setting of mode for future features
-			if (bWasPointerMode) {
+			if (bWasPointerMode && !_oLastMouseMoveTarget) {
+				// Spot last 5-way control, only if there's not already focus on screen
 				_oThis.spot(_oLast5WayControl);
 				return true;
 			}


### PR DESCRIPTION
- Add parameter to spot to indicate whether the spot was coming from an onSpotlightPoint event or not.  If not, and we're in pointer mode, that means someone called spot programmatically.  We don't want to actually move the spotlight in this case, however we cache the control passed to spot as the last 5-way control, which allows 5-way to pick up from that point.  With this, developers can call spot() without regard to the pointer mode, and won't get unwanted "flashing"
- Remove _bCanFocus - seems to be no longer needed with above change.  _comeBackFromPointerMode now spots the last 5-way control unconditionally.
- Remove check on (_oCurrent === oControl), since a control that's unspotted in pointer mode couldn't be re-spotted
- Add `spotlight` to list of properties observed for disappearance
- Require 2 mousemove events before switching to 5-way mode, to work around an issue on device where it inexplicably sends an errant mousemove event on first press of a key
- Set point mode (and come back from pointer mode) based on special key events that indicate the real pointer mode status on device; existing mousemove/5-way key-based logic still applies for use on PC
- In containers, only 5-way moves should be considered as coming from inside; avoids getting spotlight stuck if the container is being programmatically spotted and the last control was also inside of it; we now treat programmatic spots as if they are always coming from outside.
  DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
