### PR TITLE
Fixing http://jira2.lgsvl.com/browse/GF-45656

### DIFF
--- a/enyo.Spotlight.Util.js
+++ b/enyo.Spotlight.Util.js
@@ -12,7 +12,9 @@ enyo.Spotlight.Util = new function() {
 			oControl = enyo.Spotlight.getCurrent();
 		}
 		
-		oData            = oData ? enyo.clone(oData) : {};
+		oData = oData ? enyo.clone(oData) : {};
+		if (oData == null) { oData = {}; } // If clone failed on oData
+		
 		oData.type       = sEvent;
 		oData.originator = oControl;
 		oData.originator.timestamp = oData.timeStamp;


### PR DESCRIPTION
Since Spotlight.Util.dispatchEvent API is public, it is hard to predict what is being sent in parameters. In this bug, spotlight encounters a non-clonable something, which produces null. Adding a double-check for that.
