### PR TITLE
GF-46100: Don't spot first child if app has already set up the current c...

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -511,7 +511,7 @@ enyo.Spotlight = new function() {
 		_oRoot = oParams.root;
 		_interceptEvents();                          // Capture spotlight events at root level of the app
 		
-		var oFirst = _oCurrent || this.getFirstChild(oRoot);	// Spot the first child of the app, unless the app has already specified which control to spot
+		var oFirst = _oCurrent || this.getFirstChild(_oRoot);	// Spot the first child of the app, unless the app has already specified which control to spot
 
 		if (oFirst) {
 			if (!_oCurrent) {
@@ -521,7 +521,7 @@ enyo.Spotlight = new function() {
 			return true;
 		}
 		
-		throw 'Spotlight initialization failed. No spottable children found in ' + oRoot.toString(); 
+		throw 'Spotlight initialization failed. No spottable children found in ' + _oRoot.toString(); 
 	};
 	
 	// Does spotlight have _oCurrent and last5waycontrol?


### PR DESCRIPTION
...ontrol.

Allows app to call enyo.Spotlight.spot(myControl), and not have that stomped on by default behavior that focuses the first child.
DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
