### PR TITLE
GF-44951: Update not to trigger preventDefault() when inserting input fi...

### DIFF
--- a/enyo.Spotlight.Accelerator.js
+++ b/enyo.Spotlight.Accelerator.js
@@ -23,6 +23,9 @@ enyo.Spotlight.Accelerator = new function() {
 	this.processKey = function(oEvent, fCallback, oContext) {
 		switch (oEvent.type) {
 			case 'keydown':
+				if (oEvent.target && (oEvent.target.nodeName === "INPUT" || oEvent.target.nodeName === "TEXTAREA"  || (oEvent.target.nodeName === "DIV" && oEvent.target.contentEditable === "true"))) {
+					break;
+				}
 			case 'pagehold':
 			case 'pageholdpulse':
 				if (oEvent.keyCode != _nKey) {


### PR DESCRIPTION
...eld using USB-keyboard.

There are some cases not to trigger preventDefault method.

(1) input element
(2) textarea element
(3) div element with contentEditable:true.

This PR can fix GF-44951, GF-43414.

Enyo-DCO-1.1-Signed-off-by: YoungMok Kim ym1980.kim@lge.com
