### PR TITLE
GF-58554 Accordion remember last focused item.

### DIFF
--- a/decorators/kind.Spotlight.Decorator.Container.js
+++ b/decorators/kind.Spotlight.Decorator.Container.js
@@ -42,7 +42,7 @@ enyo.kind({
 				case 'onSpotlightFocus':
 					if (oEvent.originator !== oSender) {
 						enyo.Spotlight.Decorator.Container.setLastFocusedChild(oSender, oEvent.originator);
-					} 
+					}
 					break;
 				case 'onSpotlightKeyDown':
 					// Inform other controls that spotlight 5-way event was generated within a container
@@ -117,10 +117,14 @@ enyo.kind({
 		// Set last focused child
 		setLastFocusedChild: function(oSender, oChild) {
 			if (!enyo.Spotlight.isSpottable(oChild)) {
+				oChild = this.getFirstChild(oChild);
+			}
+			if (oChild) {
+				oSender._spotlight = oSender._spotlight || {};
+				oSender._spotlight.lastFocusedChild = oChild;
+			} else {
 				enyo.warn('Spotlight Container' + oSender.name + ' has not spottable lastFocusedChild ' + oChild.name);
 			}
-			oSender._spotlight = oSender._spotlight || {};
-			oSender._spotlight.lastFocusedChild = oChild;
 		}
 	}
 });


### PR DESCRIPTION
GF-58554: 5-way(up/down) key on AccordionSample move differently according to last focused item.

I sent pull request to moonstone for GF-58554(moonstone/pull/1012)

And this code is a alternative solution for GF-44975(moonstone/pull/836) 

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
