### PR TITLE
Minor fix to avoid Spotlight from interfering on touch devices.

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -580,7 +580,7 @@ enyo.Spotlight = new function() {
 	this.isInitialized = function() { return _bInitialized; };
 
 	this.setPointerMode  = function(bPointerMode) {
-		if (_bPointerMode != bPointerMode) {
+		if ((_bPointerMode != bPointerMode) && (!enyo.platform.touch)) {
 			_bPointerMode = bPointerMode;
 			_log('Pointer mode', _bPointerMode);
 			_nMouseMoveCount = 0;


### PR DESCRIPTION
Don't allow spotlight to change to 5-way mode on touch devices.
Enyo-DCO-1.1-Signed-Off-By: Kevin Schaaf (kevin.schaaf@lge.com)
