### PR TITLE
GF-58418: Null _oLastMouseMoveTarget when blurring, to cover the case of...

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -548,6 +548,7 @@ enyo.Spotlight = new function() {
 	this.onSpotlightBlur = function(oEvent) {
 		if (this.hasCurrent()) {
 			_unhighlight(oEvent.originator);
+			_oLastMouseMoveTarget = null;
 		}
 	};
 


### PR DESCRIPTION
... programmatic unspot().

I tested this with event logging enabled, and verified we get the desired events in pointer & 5-way, and that spot does occur in DataGriList after scrolling as soon as you move the pointer one pixel (don't have to exit the item and re-enter it to spot it).

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
