### PR TITLE
GF-59358: 2 Focus item on one DataGridList when focused panel is hided a...

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -75,6 +75,7 @@ enyo.Spotlight = new function() {
 			if (!oControl || !_oThis.isSpottable(oControl)) {                                       // Nothing is set in defaultSpotlightDisappear
 				oControl = _oThis.getFirstChild(_oRoot);                                            // Find first spottable in the app 
 				if (!oControl) { 
+					_unhighlight(_oLastControl);
 					_oLastControl = null;
 					_oCurrent = null;                                                       // NULL CASE :(, just like when no spottable children found on init
 					return;


### PR DESCRIPTION
...nd shown again

This issue is reported from timemachine and smartshare apps.

Problem:
1) In first panel, select a video item to see video player in 5 way
mode.
(Here app is hiding this panel and spotlight class is not removed)
2) Get back to previous panel by closing video player in pointer mode.
(Here app is showing the item list panel and previous spotlight style is
still there)
3) You can see 2 focused items.
(One is actually focused item in pointer mode, the other one is just css
styling which is not cleared when hiding the previous panel)

Cause:
1) When focused item is hided, disappear handler is called and reset
current and last control to null.
2) When focusing on other item, unspot is called but return because
current is null.

Solution:
When disappear handler is called, remove spotlight styling before set
current and last to null.

Fixing: http://jira2.lgsvl.com/browse/GF-59358
