### PR TITLE
GF-58418: Move setting _oLastMouseMoveTarget to after spot, since unspot...

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -381,10 +381,10 @@ enyo.Spotlight = new function() {
 					)
 				) { return; } // ignore consecutive mouse moves on same target
 				
+				this.spot(oTarget, null, true);
 				_oLastMouseMoveTarget = oTarget;
 				_oPointed  = oTarget;
-				
-				this.spot(oTarget, null, true);
+
 			} else {
 				_oLastMouseMoveTarget = null;
 				this.unspot();


### PR DESCRIPTION
... will now clear it, and unspot is called as part of spot.

I did end up finding an issue with the original fix for GF-58418.  Spotlight can get in a state where every mousemove results in a new blur-focus-focused cycle to occur (even when hovering over the same control).  Unfortunately, we shouldn't release as-is, since this would result in a huge flurry of events as you're moving your focus about the screen.

The original fix here was to null _oLastMouseMoveTarget when onSpotlightBlur occurs.  Normally, it will be set to null if you point at something that's not spottable, so the change was to cover the case where you programmatically call unspot() to remove focus from the screen.

The problem was that when you move pointer over a spottable control, we set _oLastMouseMoveTarget, then call spot, which causes a blur of the current control (which then clears _oLastMouseMoveTarget), so then on the next mousemove, you would try and re-spot the control.

The short-term fix here is to move setting _oLastMouseMoveTarget after the call to spot(), so that it is set.  We definitely need to re-work the logic around _oCurrent, _oLastMouseMoveTarget, _oPointed, _bFocusOnScreen, etc. once we have a chance to breathe.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
