### PR TITLE
GF-58418: Move setting _oLastMouseMoveTarget to after spot, since unspot...

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -381,10 +381,10 @@ enyo.Spotlight = new function() {
 					)
 				) { return; } // ignore consecutive mouse moves on same target
 				
+				this.spot(oTarget, null, true);
 				_oLastMouseMoveTarget = oTarget;
 				_oPointed  = oTarget;
-				
-				this.spot(oTarget, null, true);
+
 			} else {
 				_oLastMouseMoveTarget = null;
 				this.unspot();


### PR DESCRIPTION
... will now clear it, and unspot is called as part of spot.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
