### PR TITLE
GF-59152: Check target of mousedown event instead of last pointed...

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -398,6 +398,7 @@ enyo.Spotlight = new function() {
 			var oTarget = _getTarget(oEvent.target.id);
 			if (oTarget != _oCurrent && !oEvent.defaultPrevented) {
 				this.unfreeze();
+				this.unspot();
 				if (oTarget) {
 					this.spot(oTarget, null, true);
 				}


### PR DESCRIPTION
…control when deciding whether to unfreeze Spotlight.

Also, don't unfreeze if the default on the down event has been prevented.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
