### PR TITLE
GF-60177: Spotlight disappear routine in rc6 doesn't work in some case

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -604,7 +604,7 @@ enyo.Spotlight = new function() {
 			bSpottable = this.hasChildren(oControl);           // Are there spotlight=true descendants?
 		} else {
 			bSpottable = (
-				!oControl._destroyed                        && // Control has been destroyed, but not yet garbage collected
+				!oControl.destroyed                         && // Control has been destroyed, but not yet garbage collected
 				typeof oControl.spotlight != 'undefined'    && // Control has spotlight property set
 				oControl.spotlight                          && // Control has spotlight=true or 'container'
 				oControl.getAbsoluteShowing(true)           && // Control is visible


### PR DESCRIPTION
Reproduce
1. run DisappearSample.html
2. click "destroy my ancestor" button.

Expected
- spotlight moves to "I am default ..." button

Result
- spotlight is disappeared.

Solution
- we can solve this difference by checking oControl.destroyed or change
  getAbsoluteShowing of control.js to check destroy property also.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
