### PR TITLE
GF-60193: [RC.6 Sanity check] Lose focus when last focused control is no...

### DIFF
--- a/decorators/kind.Spotlight.Decorator.Container.js
+++ b/decorators/kind.Spotlight.Decorator.Container.js
@@ -117,7 +117,7 @@ enyo.kind({
 		// Set last focused child
 		setLastFocusedChild: function(oSender, oChild) {
 			if (!enyo.Spotlight.isSpottable(oChild)) {
-				oChild = this.getFirstChild(oChild);
+				oChild = enyo.Spotlight.getFirstChild(oChild);
 			}
 			if (oChild) {
 				oSender._spotlight = oSender._spotlight || {};


### PR DESCRIPTION
...t spot-table on container

This problem is reported on Sanity check of moonstone rc.6 and
introduced on bug fix for GF-58554.

There is a call to static function of spotlight from decorator.
And this makes losing focus.

Need to fix oChild = this.getFirstChild(oChild); to oChild =
enyo.Spotlight.getFirstChild(oChild);

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
