### PR TITLE
Removed the reference to the "decorators" folder...

### DIFF
--- a/package.js
+++ b/package.js
@@ -9,6 +9,5 @@ enyo.depends(
 	'enyo.Spotlight.Muter.js',
 	'enyo.Spotlight.States.js',
 	'enyo.Spotlight.TestMode.js',
-	'decorators',
 	'css'
 );


### PR DESCRIPTION
...since it doesn't exist any more, and was causing loading errors.
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
