### PR TITLE
BHV-728: Prevent sending onSpotlightContainerLeave when not actually leaving container.

### DIFF
--- a/enyo.Spotlight.Container.js
+++ b/enyo.Spotlight.Container.js
@@ -62,8 +62,11 @@ enyo.Spotlight.Container = new function() {
 
 		_focusLeave = function(oSender, s5WayEventType) {
 			// console.log('FOCUS LEAVE', oSender.name);
-			var sDirection = s5WayEventType.replace('onSpotlight','').toUpperCase();
-			enyo.Spotlight.Util.dispatchEvent('onSpotlightContainerLeave', {direction: sDirection}, oSender);
+			// Ensure we are actually leaving container (and not bouncing back to the originating control)
+			if (oSender._spotlight.lastFocusedChild !== enyo.Spotlight.getLastControl()) {
+				var sDirection = s5WayEventType.replace('onSpotlight','').toUpperCase();
+				enyo.Spotlight.Util.dispatchEvent('onSpotlightContainerLeave', {direction: sDirection}, oSender);
+			}
 		},
 
 		_focusEnter = function(oSender, s5WayEventType) {


### PR DESCRIPTION
## Issue

The `onSpotlightContainerLeave` event is sent even when focus does not actually leave the container; this occurs on 5-way move where there is nothing spottable outside of the container in the intended 5-way direction.
## Fix

In the `_focusLeave` method, we guard against this case by comparing the `lastFocusedChild` and the subsequent control that is being spotted.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
