### PR TITLE
GF-61401: Move unspot from spot to _setCurrent to reduce the dual focus - RC

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -112,6 +112,7 @@ enyo.Spotlight = new function() {
 				throw 'Attempting to spot not-spottable control: ' + oControl.toString();
 			}
 			
+			_oThis.unspot();                                                      // Remove spotlight class and Blur 
 			_highlight(oControl);                                                 // Add spotlight class 
 			
 			var oExCurrent = _oCurrent;
@@ -730,8 +731,9 @@ enyo.Spotlight = new function() {
 		}
 		
 		if (oControl) {
-			this.unspot();
+			
 			if (this.getPointerMode() && !bWasPoint) {	                              // When the user calls spot programmatically in pointer mode, we don't actually
+				this.unspot();
 				_oLastControl = oControl;                                             // under the pointer; instead we just unspot and set up the _oLastControl 
 				_oLastMouseMoveTarget = null;                                         // used when resuming 5-way focus on an arrow key press
 				_log("Spot called in pointer mode; 5-way will resume from: " + oControl.id);


### PR DESCRIPTION
...chance.

Fixing http://jira2.lgsvl.com/browse/GF-61401

Reproduce:
1) Run attached sample.
2) Move focus down to item 39 which is on the second page right most item.

Problem:
Dual focus

Expected result:
No dual focus

Solution:
When spot is called, unspot is blur current item.
But, if spot is called just after the previous spot call is done unspot but not change current control on _setCurrent then unspot from next spot call is blur the last focused item because current is not changed yet.

We can remove the time gap by calling unspot just before _unhighlight on _setCurrent and move unspot on spot function into the pointer mode case.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
