### PR TITLE
BHV-2446: Reverting change made for BHV-728 in favor of more localized fix.

### DIFF
--- a/enyo.Spotlight.Container.js
+++ b/enyo.Spotlight.Container.js
@@ -62,11 +62,8 @@ enyo.Spotlight.Container = new function() {
 
 		_focusLeave = function(oSender, s5WayEventType) {
 			// console.log('FOCUS LEAVE', oSender.name);
-			// Ensure we are actually leaving container (and not bouncing back to the originating control)
-			if (oSender._spotlight.lastFocusedChild !== enyo.Spotlight.getLastControl()) {
-				var sDirection = s5WayEventType.replace('onSpotlight','').toUpperCase();
-				enyo.Spotlight.Util.dispatchEvent('onSpotlightContainerLeave', {direction: sDirection}, oSender);
-			}
+			var sDirection = s5WayEventType.replace('onSpotlight','').toUpperCase();
+			enyo.Spotlight.Util.dispatchEvent('onSpotlightContainerLeave', {direction: sDirection}, oSender);
 		},
 
 		_focusEnter = function(oSender, s5WayEventType) {


### PR DESCRIPTION
## Issue

Making the `onSpotlightContainerLeave` event only dispatch when focus had actually left the container breaks functionality in `moon.Panels` as `moon.Panels` handles the leaving of a panel on its own via this event.
## Fix

We revert the original change and move the fix to `moon.Scroller` where the original issue that prompted this fix had been occurring.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
