### PR TITLE
modify _handleEvent function in enyo.Spotlight.Container for event-bubble-feature

### DIFF
--- a/enyo.Spotlight.Container.js
+++ b/enyo.Spotlight.Container.js
@@ -39,6 +39,7 @@ enyo.Spotlight.Container = new function() {
 
 		// Handle events bubbling from within the container
 		_handleEvent = function(oSender, oEvent) {
+			oSender.cachePoint = true;
 			switch (oEvent.type) {
 				case 'onSpotlightFocus':
 					if (oEvent.originator !== oSender) {


### PR DESCRIPTION
modify _handleEvent function in enyo.Spotlight.Container to enable that the component which is spotlight container can be cached

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
