### PR TITLE
Fix for: BHV-10775

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -462,11 +462,15 @@ enyo.Spotlight = new function() {
 				this.setPointerMode(true);
 				return false; 
 			case KEY_POINTER_HIDE:                               // Pointer hidden event; set pointer mode false
-				this.setPointerMode(false);
-				if (!_oLastMouseMoveTarget) {                    // Spot last 5-way control, only if there's not already focus on screen
-					enyo.asyncMethod(this, function() { _spotLastControl(); });
-				}
-				_setTimestamp();
+				setTimeout(function () {
+					if (this.getPointerMode()) {
+						this.setPointerMode(false);
+						if (!_oLastMouseMoveTarget) {                    // Spot last 5-way control, only if there's not already focus on screen
+							enyo.asyncMethod(this, function() { _spotLastControl(); });
+						}
+						_setTimestamp();
+					}
+				}.bind(this), 30);
 				return false;
 		}
 


### PR DESCRIPTION
we need to handle the special KEY_POINTER_HIDE event later than normal operation and ensure we check the pointer state before blindly spotting the 'last' control

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
