### PR TITLE
BHV-10909: Header/Input: 'Dismiss On Enter' does not Dismiss but Reloads VKB

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -23,7 +23,7 @@ enyo.Spotlight = new function() {
 		_bFrozen                        = false,    // While frozen, current cannot change and all events are directed to it.
 		_oDefaultDisappear              = null,     // Contains control specified in defaultSpotlightDisappear property of _oCurrent
 		_bFocusOnScreen                 = false,    // Whether focus is currently visible on screen or not (hasCurrent && !pointingAway) ??
-		_bLastKeyDownIgnored            = false,    // Whether last key down was ignored because the spotted control had it spotlightIgnoredKeys
+		_bLastKeyDownIgnored            = false,    // Whether last key down was ignored because the spotted control had it in spotlightIgnoredKeys
 
 		_nMouseMoveCount                = 0,        // Number of consecutive mousemoves; require >1 to switch to pointer mode
 		_nPrevClientX                   = null,


### PR DESCRIPTION
### Issue:

moon.Input instructs Spotlight to ignore enter key events, and then handles key up events to remove focus when dismissOnEnter is true, and the keyCode is an enter key. When selection logic was moved from spotlightKeyDown to spotlightKeyUp, this caused problems with the dismissOnEnter feature of moon.Input, because the enter keyDown event was being ignored, but the enter keyUp was not, because by the time OnSpotlightKeyUp executes, input no longer has the focus.
### Fix:

Add a bool _bLastKeyDownIgnored, and then check to see the selection logic is not performed if _bLastKeyDownIgnored is true.
