### PR TITLE
BHV-10909: Fixing DismissOnEnter on moon.Input

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -512,7 +512,7 @@ enyo.Spotlight = new function() {
 	
 	this.onKeyUp = function(oEvent) {
 		if (_isIgnoredKey(oEvent)) {
-			return true;
+			return false;
 		}
 		enyo.Spotlight.Accelerator.processKey(oEvent, this.onAcceleratedKey, this);
 		return false; // Always allow key events to bubble regardless of what onSpotlight** handlers return


### PR DESCRIPTION
### Problem:

DismissnEnter is not working.
### Analysis:

This is regression which is introduced after changing spotlight select timing from onKeyDown to onKeyUp.
Original sequence when onSpotlightSelect is fired on onKeyDown
1) Spotlight: onKeyDown -> return false (onSpotlightSelect is not comes)
2) Input: onkeypress -> blur (This makes focus goes to decorator)
3) Spotlight: onkeyUp -> not able to return true (because event target is not input after blur)
Current sequence when onSpotlightSelect is fired on onKeyUp
1) Spotlight: onKeyDown -> return false
2) Input: onkeypress -> blur (This makes focus goes to decorator)
3) Spotlight: onKeyUp -> not able to return true (because event target is not input after blur)
4) Spotlight: onSpotlightKeyUp -> onSpotlightSelect -> ontap (This makes focus goes to input again)
### Solution:

Change onkeypress handler as onkeyup, so that event target is not changed until 3).
Change return true as false, so that onSpotlightKeyUp is not bubbled up.

When user type enter on input, spotlight onKeyUp handler is called and checking spotlightIgnoredKeys then returning true.
This makes onkeyup event is not comes to input.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
