### PR TITLE
BHV-11383 : modify _oCurrent property's sync time

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -117,10 +117,10 @@ enyo.Spotlight = new function() {
 				throw 'Attempting to spot not-spottable control: ' + oControl.toString();
 			}
 			
+			var oExCurrent = _oCurrent;
+
 			_oThis.unspot();                                                      // Remove spotlight class and Blur 
 			_highlight(oControl);                                                 // Add spotlight class 
-			
-			var oExCurrent = _oCurrent;
 			
 			_oCurrent = oControl;
 			setTimeout(function() {                                               // Set observers asynchronously to allow painti to happen faster
@@ -388,9 +388,7 @@ enyo.Spotlight = new function() {
 
 			} else {
 				_oLastMouseMoveTarget = null;
-				if(this.unspot()) {
-					_oCurrent = null;
-				}
+				this.unspot();
 			}
 		}
 		
@@ -768,6 +766,7 @@ enyo.Spotlight = new function() {
 			_unhighlight(_oCurrent);
 			_oLastMouseMoveTarget = null;
 			_dispatchEvent('onSpotlightBlur', null, _oCurrent);
+			_oCurrent = null;
 			return true;
 		}
 		return false;


### PR DESCRIPTION
### Problem that cause the issue

_oCurrent is not synced exactly with 'current spotted control'
### Analysis

After https://github.com/enyojs/spotlight/pull/135 PR, 'spot' function check _oCurrent and oControl and return 'true' immediatly if it is same.
However, currently _oCurrent is not synced exactly with 'current spotted control'
Somtimes, when there is no spotted control, _oCurrent indicates ex-spotted control.
So, update _oCurrent property in Spotlight.js to sync accurately with current spotlight control.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
