### PR TITLE
BHV-13376: make Spotlight can't throws exception in freeze function

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -811,11 +811,13 @@ enyo.Spotlight = new function() {
 	
 	// Switching to frozen mode (current cannot change while frozen)
 	this.freeze = function() {
-		if (!this.hasCurrent()) { throw 'Can not enter frozen mode until something is spotted'; }
-		_bFrozen = true;
-		return 'SPOTLIGHT: Frozen on ' + _oCurrent.toString(); 
+		if (this.hasCurrent()) {
+			_bFrozen = true;
+		} else {
+			_warn('Can not enter frozen mode until something is spotted');
+		}
 	};
-	this.unfreeze = function() { _bFrozen = false; return 'SPOTLIGHT: Exit frozen mode';  };
+	this.unfreeze = function() { _bFrozen = false; };
 	this.isFrozen = function() { return _bFrozen;  };
 
 	// Highlighting


### PR DESCRIPTION
## Issue

Spotlight throws exception when using VideoPlayer
## Problem

After 2.5.0, _oCurrent is 'null' when spotlight is not pointing any control. So whenever user/framework call freeze function when _oCurrent is null, freeze function throws exception and script is stopped. It has a risk for triggering abnormal behavior on runtime
## Fix

make Spotlight can't throws exception in freeze function and change to give a warning msg.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
