### PR TITLE
CMB-1706: Spotlight: Unnatural behavior when focus moves from datagridli...

### DIFF
--- a/enyo.Spotlight.NearestNeighbor.js
+++ b/enyo.Spotlight.NearestNeighbor.js
@@ -210,11 +210,14 @@ enyo.Spotlight.NearestNeighbor = new function() {
 
 		// If default control in the directin of navigation is not specified, calculate it
 
-		var oBounds = oControl.getAbsoluteBounds(),
-			o       = enyo.Spotlight.getSiblings(oControl);
+		var oBounds   = null,
+			o         = enyo.Spotlight.getSiblings(oControl),
+			oPrevious = enyo.Spotlight.getPrevious();
 
-		if (oControl.spotlight && oControl.spotlight == "container" && enyo.Spotlight.getExCurrent()) {
-			oBounds = enyo.Spotlight.getExCurrent().getAbsoluteBounds();
+		if (oControl.spotlight && oControl.spotlight == "container" && oPrevious) {
+			oBounds = oPrevious.getAbsoluteBounds();
+		} else {
+			oBounds = oControl.getAbsoluteBounds();
 		}
 
 		return _calculateNearestNeighbor(o.siblings, sDirection, oBounds, oControl);

--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -14,7 +14,7 @@ enyo.Spotlight = new function() {
 		_bPointerMode                   = true,     // Is spotlight in pointer mode or 5way mode?
 		_bInitialized                   = false,    // Does spotlight have _oCurrent
 		_oCurrent                       = null,     // Currently spotlighted element
-		_oExCurrent                     = null,     // Previously spotlighted element
+		_oPrevious                      = null,     // Previously spotlighted element
 		_oLastEvent                     = null,     // Last event received by Spotlight
 		_oLast5WayEvent                 = null,     // Last 5way event received by Spotlight
 		_oLastControl                   = null,     // Last non-container (spotlight:true) control that was _oCurrent
@@ -118,14 +118,14 @@ enyo.Spotlight = new function() {
 				throw 'Attempting to spot not-spottable control: ' + oControl.toString();
 			}
 			
-			_oExCurrent = _oCurrent;
+			_oPrevious = _oCurrent;
 
 			_oThis.unspot();                                                      // Remove spotlight class and Blur 
 			_highlight(oControl);                                                 // Add spotlight class 
 			
 			_oCurrent = oControl;
 			setTimeout(function() {                                               // Set observers asynchronously to allow painti to happen faster
-				_observeDisappearance(false, _oExCurrent);
+				_observeDisappearance(false, _oPrevious);
 				_observeDisappearance(true, _oCurrent);
 			}, 1);
 				
@@ -610,7 +610,7 @@ enyo.Spotlight = new function() {
 	this.getCurrent           = function()                { return _oCurrent;               };
 	this.setCurrent           = function(oControl)        { return _setCurrent(oControl);   };
 	this.hasCurrent           = function()                { return _oCurrent !== null;      };
-	this.getExCurrent         = function()                { return _oExCurrent;             };
+	this.getPrevious          = function()                { return _oPrevious;              };
 	this.getLastEvent         = function()                { return _oLastEvent;             };
 	this.getLastControl       = function()                { return _oLastControl;           };
 	this.getLast5WayEvent     = function()                { return _oLast5WayEvent;         };


### PR DESCRIPTION
...st item to paging controls
### Issue:

Focus move between grid list items to paging controls feels not natural.
Focus doesn't move from items to paging down button.
This is because viewport is spotlight "container" and paging controls are outside of container.
Spotlight is find nearest from container to other controls.
But, users don't know about 'container' because it is invisible component.
### Fix:

To make focus move between container to other control more natural,
spotlight should compare position from ex current not container itself.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
