### PR TITLE
Fixes BHV-13871

### DIFF
--- a/enyo.Spotlight.NearestNeighbor.js
+++ b/enyo.Spotlight.NearestNeighbor.js
@@ -183,7 +183,7 @@ enyo.Spotlight.NearestNeighbor = new function() {
                 angle = _getAngle(slope),
                 distance = _getDistance(delta);
 
-            return angle > 89 ? 0 : 1 / (angle * Math.pow(distance, 4));
+            return angle > 90 ? 0 : 1 / (angle * Math.pow(distance, 4));
         },
 
         /**


### PR DESCRIPTION
## Issue

Controls that were in the half plane but were very close to the edge were treated as ineligible to be the nearest neighbor
## Fix

Adjust precedence calculation to include all elements in the half plane
