### PR TITLE
Fixes CMB-1875

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -217,7 +217,17 @@ enyo.Spotlight = new function() {
         * @default false
         * @private
         */
-        _bCancelHold = false;
+        _bCancelHold = false,
+        
+        /**
+        * If a key down was ignored, be sure to ignore the following key up. Specifically, this
+        * works around the different target keyup for Enter for inputs (input on down, body on up).
+        *
+        * @type {Number}
+        * @default 0
+        * @private
+        */
+        _nIgnoredKeyDown = 0;
 
 
         /**
@@ -1043,7 +1053,10 @@ enyo.Spotlight = new function() {
     this.onKeyDown = function(oEvent) {
 
         if (_isIgnoredKey(oEvent)) {
+            _nIgnoredKeyDown = oEvent.which;
             return false;
+        } else {
+            _nIgnoredKeyDown = 0;
         }
 
         // Update pointer mode based on special keycode from
@@ -1111,7 +1124,7 @@ enyo.Spotlight = new function() {
     };
 
     this.onKeyUp = function(oEvent) {
-        if (_isIgnoredKey(oEvent)) {
+        if (_nIgnoredKeyDown === oEvent.which || _isIgnoredKey(oEvent)) {
             return false;
         }
         enyo.Spotlight.Accelerator.processKey(oEvent, this.onAcceleratedKey, this);


### PR DESCRIPTION
## Issue

The cause of the bug is a target change between the keydown and keyup events when hitting Enter on an Input. The keydown targets the input but then it's blurred so the keyup targets body. As a result, the keyup triggers Spotlight to send a onSpotlightFocus event to the InputDecorator which, in turn, refocus the input which freezes Spotlight.
## Fix

Ignores keyup event if keydown event for same key was ignored

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
