### PR TITLE
[BHV-14150]PopupSample: Moonstone Popup closes abnormally on spotlight events

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -315,7 +315,8 @@ enyo.Spotlight = new function() {
                 if (!oControl) {
                     _unhighlight(_oLastControl);
                     _oLastControl = null;
-
+                    
+                    _observeDisappearance(false, _oCurrent);
                     // NULL CASE :(, just like when no spottable children found on init
                     _oCurrent = null;
                     return;
@@ -1566,6 +1567,7 @@ enyo.Spotlight = new function() {
             _unhighlight(_oCurrent);
             _oLastMouseMoveTarget = null;
             _dispatchEvent('onSpotlightBlur', null, _oCurrent);
+            _observeDisappearance(false, _oCurrent);
             _oCurrent = null;
             return true;
         }


### PR DESCRIPTION
Issue: _onDisappear routine is being triggered on a control which
doesn't have focus.
Analysis: _onDisappear  routine should be triggered only based on the
current focused control. If there is no _oCurrent control, there is no
need of observing any of the  _onDisappear events.
Fix: whenever _oCurrent = null , _observeDisappearance(false, _oCurrent)
is called.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P rajyavardhan.p@lge.com
