### PR TITLE
Fixes CMB-1706

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -446,7 +446,8 @@ enyo.Spotlight = new function() {
         */
         _5WayMove = function(oEvent) {
             var sDirection = oEvent.type.replace('onSpotlight', '').toUpperCase(),
-                oControl = enyo.Spotlight.NearestNeighbor.getNearestNeighbor(sDirection);
+                leave = oEvent.requestLeaveContainer,
+                oControl = !leave && enyo.Spotlight.NearestNeighbor.getNearestNeighbor(sDirection);
 
 
             // If oEvent.allowDomDefault() was not called


### PR DESCRIPTION
## Issue

Unnatural behavior when focus moves from datagridlist item to paging controls
## Fix

Move spotlight container back to Scroller and decorate spotlight events originating from paging controls to skip nearest neighbor determination
## Note

Require enyojs/moonstone#1618

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
