### PR TITLE
[BHV-15215]Correct control is not spotted when moving ou...

### DIFF
--- a/enyo.Spotlight.NearestNeighbor.js
+++ b/enyo.Spotlight.NearestNeighbor.js
@@ -363,16 +363,18 @@ enyo.Spotlight.NearestNeighbor = new function() {
 			}
 		}
 
-        // If default control in the directin of navigation is not specified, calculate it
+        // If default control in the direction of navigation is not specified, calculate it
 
-        var o = enyo.Spotlight.getSiblings(oControl);
+        var o = enyo.Spotlight.getSiblings(oControl),
+            oBounds;
+
         // If the control is container, the nearest neighbor is calculated based on the bounds
         // of last focused child of container.
-        if(enyo.Spotlight.isContainer(oControl)) {
+        if (enyo.Spotlight.isContainer(oControl)) {
             oControl = enyo.Spotlight.Container.getLastFocusedChild(oControl) || oControl;
         }
 
-        var oBounds = oControl.getAbsoluteBounds();
+        oBounds = oControl.getAbsoluteBounds();
 
         return _calculateNearestNeighbor(o.siblings, sDirection, oBounds, oControl);
     };


### PR DESCRIPTION
...t of datagridlist.""

Issue: when spot moves out of any container, the nearest
neighbor
algorithm finds the neighbor based on the container bounds.
That is causing the issue.
Fix:  getNearestNeighbor method is updated to
consider the 'container' scenario and changed the bounds to container to
container's focused child.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P rajyavardhan.p@lge.com
