### PR TITLE
BHV-17798: onholdulse event is not getting right delay value from holdPu...

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -1686,7 +1686,7 @@ enyo.Spotlight = new function() {
     */
     this.getHoldPulseDelay = function(oEvent) {
         var drag = enyo.gesture.drag;
-        return Object.keys(drag.holdPulseConfig).length > 0 ? drag.holdPulseConfig.delay : drag.holdPulseDefaultConfig.delay;
+        return Object.keys(drag.holdPulseConfig).length > 0 ? drag.holdPulseConfig.frequency : drag.holdPulseDefaultConfig.frequency;
     };
 
     /**


### PR DESCRIPTION
...lseDefaultConfig
### Issue:

Drag.js file has changed to support custom event type.
In this change, default delay value is removed and frequency is added.
Spotlight is referencing delay variable fro drag.js but spotlight is not updated to reference frequency.
### Fix:

Change delay to frequency variable.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
