### PR TITLE
ENYO-508: Guard against the absence of a last (blurred) control.

### DIFF
--- a/enyo.Spotlight.Container.js
+++ b/enyo.Spotlight.Container.js
@@ -72,7 +72,7 @@ enyo.Spotlight.Container = new function() {
                     oEvent.spotSentFromContainer = true;
                     break;
                 case 'onSpotlightContainerEnter':
-                    if(oEvent.last.isDescendantOf(oSender)) {
+                    if(oEvent.last && oEvent.last.isDescendantOf(oSender)) {
                         return true;
                     }
                     break;


### PR DESCRIPTION
### Issue

We made some recent changes to Spotlight Container events recently, which utilize the blurred and focused controls to determine whether or not to fire the container events. In the case of Sampler, when Spotlight is initialized upon first load, `_oLastControl_` remains assigned to `null`. Thus, the first time we attempt to spot a control in a sample, because Spotlight is not reloaded due to the nature of how Sampler loads samples, we pass the value of `_oLastControl`, which is still `null`, as the "blurred" control, causing an error. For individual samples loaded outside of Sampler, we are loading Spotlight at the same time the sample is loaded, and the initialization will set a non-null value for `_oLastControl_`. This could have a potential app impact if the first screen of the app has no spottable controls.
### Fix

We now guard against a falsy value for `oEvent.last` in our conditional.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
