### PR TITLE
Fixes ENYO-556

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -47,7 +47,11 @@ enyo.Spotlight = new function() {
         _bInitialized = false,
 
         /**
-        * Indicates if a control was spotted as a result of a key down event
+        * State variable allowing us to suppress Spotlight select on
+        * keyup in the specific case where a press of the [Enter] key
+        * has just triggered a switch from pointer mode to 5-way mode
+        * (since we only want to switch modes in this case, not perform
+        * a selection)
         * @type {Boolean}
         * @default false
         * @private


### PR DESCRIPTION
## Issue

Regression from BHV-4645 - By moving the onSpotlightSelect dispatch to the key up handler, the key down handler handles the Enter key by dropping out of pointer mode and spotting the nearest control and the key up handler then selects the active control causing the popup to render.
## Fix

Remember that a control was spotted as a result of a key down event and, if so, kick out of spotlight's key up handler to avoid taking a second Spotlight action on the same key press.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
