### PR TITLE
BHV-19913: Don't fire spotlightSelect event while holdpulse event fires.

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -1057,7 +1057,9 @@ enyo.Spotlight = new function() {
         var ret = true;
         switch (oEvent.keyCode) {
             case 13:
-                ret = _dispatchEvent('onSpotlightSelect', oEvent);
+                if (!enyo.gesture.drag.isPulsing()) {
+                    ret = _dispatchEvent('onSpotlightSelect', oEvent);
+                }
                 enyo.gesture.drag.endHold();
         }
 


### PR DESCRIPTION
Issue:
We don't want to fire spotlightSelect event while holdpulse event fire. Because these event can have very short time gap for some times.

Fix:
Added a function isPulsing() in drag.js and based on this._pulsing firing the spotlightSelect event

DCO-1.1-Signed-Off-By: Anshu Agrawal anshu.agrawal@lge.com
