### PR TITLE
BHV-19913: Don't fire spotlightSelect event while holdpulse event fires. (2.5)

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -1057,7 +1057,9 @@ enyo.Spotlight = new function() {
         var ret = true;
         switch (oEvent.keyCode) {
             case 13:
-                ret = _dispatchEvent('onSpotlightSelect', oEvent);
+                if (!enyo.gesture.drag.isPulsing()) {
+                    ret = _dispatchEvent('onSpotlightSelect', oEvent);
+                }
                 enyo.gesture.drag.endHold();
         }
 


### PR DESCRIPTION
Cherry-picking the changes from https://github.com/enyojs/spotlight/pull/160 into `2.5-upkeep`, creating a PR for tracking purposes.
