### PR TITLE
ENYO-924: Dual focus when system popup (Overlay style app) shown

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -685,6 +685,13 @@ enyo.Spotlight = new function() {
         // Events only processed when Spotlight initialized with a root
         if (this.isInitialized()) {
             switch (oEvent.type) {
+                case 'focus':
+                    // Call webOS TV platform API (new) here to update current pointer mode
+                    if (PalmSystem && PalmSystem.cursor)
+                        this.setPointerMode( PalmSystem.cursor.visibility );
+                    // When app is go to background then unspot focus
+                    this.spot(this.getLastControl());
+                    break;
                 case 'blur':
                     // When app is go to background then unspot focus
                     this.unspot();

--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -685,6 +685,10 @@ enyo.Spotlight = new function() {
         // Events only processed when Spotlight initialized with a root
         if (this.isInitialized()) {
             switch (oEvent.type) {
+                case 'blur':
+                    // When app is go to background then unspot focus
+                    this.unspot();
+                    break;
                 case 'move':
 
                     // Only register mousemove if the x/y actually changed,

--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -687,18 +687,19 @@ enyo.Spotlight = new function() {
             switch (oEvent.type) {
                 case 'focus':
                     if (oEvent.target === window) {
-                        // Call webOS TV platform API (new) here to update current pointer mode
+                        // Update pointer mode from cursor visibility platform API
                         if (window.PalmSystem && window.PalmSystem.cursor) {
                             this.setPointerMode( window.PalmSystem.cursor.visibility );
                         }
-                        // When app is go to background then unspot focus
+                        // Whenever app goes to foreground, refocus on last focused control
                         this.spot(this.getLastControl());
                     }
                     break;
                 case 'blur':
-                    // When app is go to background then unspot focus
-                    if (oEvent.target === window) 
+                    if (oEvent.target === window) {
+                        // Whenever app goes to background, unspot focus
                         this.unspot();
+                    }
                     break;
                 case 'move':
 

--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -687,8 +687,9 @@ enyo.Spotlight = new function() {
             switch (oEvent.type) {
                 case 'focus':
                     // Call webOS TV platform API (new) here to update current pointer mode
-                    if (PalmSystem && PalmSystem.cursor)
-                        this.setPointerMode( PalmSystem.cursor.visibility );
+                    if (window.PalmSystem && window.PalmSystem.cursor) {
+                        this.setPointerMode( window.PalmSystem.cursor.visibility );
+                    }
                     // When app is go to background then unspot focus
                     this.spot(this.getLastControl());
                     break;

--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -686,16 +686,19 @@ enyo.Spotlight = new function() {
         if (this.isInitialized()) {
             switch (oEvent.type) {
                 case 'focus':
-                    // Call webOS TV platform API (new) here to update current pointer mode
-                    if (window.PalmSystem && window.PalmSystem.cursor) {
-                        this.setPointerMode( window.PalmSystem.cursor.visibility );
+                    if (oEvent.target === window) {
+                        // Call webOS TV platform API (new) here to update current pointer mode
+                        if (window.PalmSystem && window.PalmSystem.cursor) {
+                            this.setPointerMode( window.PalmSystem.cursor.visibility );
+                        }
+                        // When app is go to background then unspot focus
+                        this.spot(this.getLastControl());
                     }
-                    // When app is go to background then unspot focus
-                    this.spot(this.getLastControl());
                     break;
                 case 'blur':
                     // When app is go to background then unspot focus
-                    this.unspot();
+                    if (oEvent.target === window) 
+                        this.unspot();
                     break;
                 case 'move':
 


### PR DESCRIPTION
This fix needs core change https://github.com/enyojs/enyo/pull/1018 before testing.

### Issue:
On app change state between BG and FG, spotlight is not getting any notice.
While focus is on app, it is not blurred because it is not getting any event when app  goes to BG.

### Fix:
- Add blur on windowEvents array to handle on dispatcher feature. (Core) https://github.com/enyojs/enyo/pull/1018
- Blur focus when onblur event comes to Spotlight.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com