### PR TITLE
ENYO-887 If a control is out of viewport, we will not spot it.

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -1405,6 +1405,12 @@ enyo.Spotlight = new function() {
             return true;
         }
 
+        var oBounds = oControl.getAbsoluteBounds();
+        // if oControl is out of veiwport
+        if (oBounds.bottom < 0 || oBounds.right < 0) {
+            return false;
+        }
+
         // Cannot spot falsy values
         if (!oControl) {
             return false;


### PR DESCRIPTION
Issue
-------
In fitstUse app, user can focus some controls which are out of viewport.

Cause
--------
1. FirstUse app does not have guide code like spotlightDisable = true when its custom panels changes index.
2. Spotlight does not concern control's absoluteBounds when it spot.

Fix
----
Add a condition to check its absoluteBounds

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com