### PR TITLE
ENYO-1098: Use simulated flag to distinguish generated tap event

### DIFF
--- a/enyo.Spotlight.Util.js
+++ b/enyo.Spotlight.Util.js
@@ -215,7 +215,7 @@ enyo.Spotlight.Util = new function() {
     */
     this.isSimulatedClick = function(oEvent) {
         return (
-            oEvent.simulated &&
+            oEvent.clientX === 0 && oEvent.clientY === 0 &&
             (oEvent.type == 'click' || oEvent.type == 'tap')
         );
     };

--- a/enyo.Spotlight.Util.js
+++ b/enyo.Spotlight.Util.js
@@ -215,7 +215,7 @@ enyo.Spotlight.Util = new function() {
     */
     this.isSimulatedClick = function(oEvent) {
         return (
-            oEvent.clientX === 0 && oEvent.clientY === 0 &&
+            oEvent.simulated &&
             (oEvent.type == 'click' || oEvent.type == 'tap')
         );
     };

--- a/enyo.Spotlight.Util.js
+++ b/enyo.Spotlight.Util.js
@@ -215,7 +215,7 @@ enyo.Spotlight.Util = new function() {
     */
     this.isSimulatedClick = function(oEvent) {
         return (
-            oEvent.clientX === 0 && oEvent.clientY === 0 &&
+            oEvent.clientX === 0 && oEvent.clientY === 0 && !oEvent.detail &&
             (oEvent.type == 'click' || oEvent.type == 'tap')
         );
     };


### PR DESCRIPTION
### Issue:
When (0, 0) is tapped on drawers, drawers do not open/close.
We have a code to filter out simulated click event in Spotlight onClick handler.
And, it is checking clientX/clientY == 0 to know is that a simulated event.
That is eventually filter out normal click event also.

### Fix:
Add a flag to indicate the event is generated from click event.
This can be used in Spotlight to exactly distinguish simulated event.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com