### PR TITLE
ENYO-1439 last focused item is focused during app swiching.

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -716,6 +716,7 @@ enyo.Spotlight = new function() {
                     if (oEvent.target === window) {
                         // Whenever app goes to background, unspot focus
                         this.unspot();
+                        this.setPointerMode(false);
                     }
                     break;
                 case 'move':


### PR DESCRIPTION
##Issue

This issue is found on SmartShare app and we have DEV tracker issue.
When app switching occurs, last focused item is still focused.
more specific, if launching quick setting in smartshare app, then focused item is still focused even after quick setting launched and came back to smartshare.

Step to reproduce
1. Open smartshare app,
2. focus on first item in pointer mode.
3. launch quick setting by pressing settings button
4. See the last focused item.

Problem
The last focused item is still focused.

##FIx

smartshare app is get Cursor Hide event (KeyDown) just after getting the focus event.
The onKeyDown handler is set pointer mode as false only when it is true then spot on last focus.
Following settings button doesn't goes into this logic because it is already in 5way mode.
So, this problem happens only when pressing settings button in pointer mode.
So, We can fix this by setting pointer mode as false on window focus event.

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung2.lee@lge.com