### PR TITLE
ENYO-1444: Add `spotlightRememberFocus` feature for containers

### DIFF
--- a/enyo.Spotlight.Container.js
+++ b/enyo.Spotlight.Container.js
@@ -138,12 +138,29 @@ enyo.Spotlight.Container = new function() {
     * @public
     */
     this.onSpotlightFocused = function(oSender, oEvent) {
+        var o5WayEvent,
+            s5WayEventType,
+            o5WayEventOriginator,
+            oChildToFocus;
+
         if (enyo.Spotlight.isInitialized() && enyo.Spotlight.getPointerMode()) {
             return true;
         }
         _initComponent(oSender);
 
-        var s5WayEventType = enyo.Spotlight.getLast5WayEvent() ? enyo.Spotlight.getLast5WayEvent().type : '';
+        // Extract info from the 5-way event that got us here. We
+        // may need this info to focus the proper child, or to
+        // redispatch the event for procssing by other containers
+        o5WayEvent = enyo.Spotlight.getLast5WayEvent();
+        if (o5WayEvent) {
+            s5WayEventType = o5WayEvent.type;
+            // Containers with `spotlightRememberFocus: false` need to know about
+            // the 'original' (non-container) originator of the event, so we pass
+            // it around using the `_originator` property
+            o5WayEventOriginator = o5WayEvent._originator ?
+                o5WayEvent._originator :
+                o5WayEvent.originator;
+        }
 
         // Focus came from inside AND this was a 5-way move
         if (_hadFocus(oSender)) {
@@ -152,7 +169,8 @@ enyo.Spotlight.Container = new function() {
                 // Re-dispatch 5 way event
                 enyo.Spotlight.Util.dispatchEvent(
                     s5WayEventType, {
-                        spotSentFromContainer: true
+                        spotSentFromContainer: true,
+                        _originator: o5WayEventOriginator
                     },
                     oSender
                 );
@@ -160,16 +178,33 @@ enyo.Spotlight.Container = new function() {
 
             // Focus came from outside or this was a programmatic spot
         } else {
-            var oLastFocusedChild = this.getLastFocusedChild(oSender);
-            if (oLastFocusedChild) {
-                enyo.Spotlight.spot(oLastFocusedChild);
+            // Default container behavior is to refocus the last-focused child, but
+            // some containers may prefer to focus the child nearest the originator
+            // of the 5-way event
+            if (o5WayEvent && oSender.spotlightRememberFocus === false) {
+                oChildToFocus = enyo.Spotlight.NearestNeighbor.getNearestNeighbor(
+                    // 5-way direction
+                    s5WayEventType.replace('onSpotlight', '').toUpperCase(),
+                    // The true (non-container) originator of the 5-way event
+                    o5WayEventOriginator,
+                    // To scope our search to children of the container, we
+                    // designate it as the root
+                    {root: oSender}
+                );
+            }
+            if (!oChildToFocus) {
+                oChildToFocus = this.getLastFocusedChild(oSender);
+            }
+            if (oChildToFocus) {
+                enyo.Spotlight.spot(oChildToFocus);
             } else {
                 if (s5WayEventType) {
 
                     // Re-dispatch 5 way event
                     enyo.Spotlight.Util.dispatchEvent(
                         s5WayEventType, {
-                            spotSentFromContainer: true
+                            spotSentFromContainer: true,
+                            _originator: o5WayEventOriginator
                         },
                         oSender
                     );

--- a/enyo.Spotlight.NearestNeighbor.js
+++ b/enyo.Spotlight.NearestNeighbor.js
@@ -345,12 +345,17 @@ enyo.Spotlight.NearestNeighbor = new function() {
     * @returns {Object} The nearest neighbor of the control.
     * @public
     */
-    this.getNearestNeighbor = function(sDirection, oControl) {
+    this.getNearestNeighbor = function(sDirection, oControl, oOpts) {
+        var oRoot = oOpts && oOpts.root,
+            oNeighbor,
+            oCandidates,
+            oBounds;
+
         sDirection = sDirection.toUpperCase();
         oControl = oControl || enyo.Spotlight.getCurrent();
 
         // Check to see if default direction is specified
-        var oNeighbor = enyo.Spotlight.Util.getDefaultDirectionControl(sDirection, oControl);
+        oNeighbor = enyo.Spotlight.Util.getDefaultDirectionControl(sDirection, oControl);
 		if (oNeighbor) {
 			if (enyo.Spotlight.isSpottable(oNeighbor)) {
 				return oNeighbor;
@@ -364,8 +369,11 @@ enyo.Spotlight.NearestNeighbor = new function() {
 
         // If default control in the direction of navigation is not specified, calculate it
 
-        var o = enyo.Spotlight.getSiblings(oControl),
-            oBounds;
+        // If we've been passed a root, find the best match among its children;
+        // otherwise, find the best match among siblings of the reference control
+        oCandidates = oRoot ?
+            enyo.Spotlight.getChildren(oRoot) :
+            enyo.Spotlight.getSiblings(oControl).siblings;
 
         // If the control is container, the nearest neighbor is calculated based on the bounds
         // of last focused child of container.
@@ -375,6 +383,6 @@ enyo.Spotlight.NearestNeighbor = new function() {
 
         oBounds = oControl.getAbsoluteBounds();
 
-        return _calculateNearestNeighbor(o.siblings, sDirection, oBounds, oControl);
+        return _calculateNearestNeighbor(oCandidates, sDirection, oBounds, oControl);
     };
 };


### PR DESCRIPTION
Historically, a Spotlight container has always restored focus to
its last-spotted child when focus was returned to the container via
a 5-way event.

In some cases, though, it would be preferable to let Spotlight's
nearest-neighbor algorithm find and focus the container child
closest to the 5-way event's originating control. This would be
useful in cases (like a scroller) where we want to keep focus
inside the container by default, but where it's not important (and
may be confusing) to restore focus state when the container is
re-entered.

In this change, we implement a simple version of this feature. If
a container has the property `spotlightRememberFocus: false`, then
we let the nearest-neighbor algorithm find the child to spot when
the container gets 5-way focus.

This simple implementation should be useful in many cases, but in
some cases it may not yield the desired results. Specifically, you
might expect the children of a `spotlightRememberFocus: false`
container to be 'promoted' by the nearest-neighbor algorithm to be
seen as peers to the siblings of the container itself. This
implementation doesn't do that, so a child of the container will
only get focus if the nearest-neighbor algorithm first selects the
container from among its siblings. It would have required much more
significant (and therefore riskier) changes to promote the
container's children, so I opted not to do that for now.

A similar case where you may see surprising results is when
a `spotlightRememberFocus: false` container is nested within
another container that does remember its last focused child. In
this case, the outer container will get to handle the 5-way event
first and may re-spot a different (more recently focused) child,
even if a child of the `spotlightRememberFocus: false` container
appears to be the nearest neighbor of the originating control.

I suspect that we'll want to significantly rework Spotlight in the
not-too-distant future, at which point we can potentially provide a
more complete implementation of this feature.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)