### PR TITLE
ENYO-1129: Accessibility: Readout text when focus on moonstone compon…

### DIFF
--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -3,6 +3,7 @@ var
     gesture = require('enyo/gesture'),
     logger = require('enyo/logger'),
     master = require('enyo/master'),
+    options = require('enyo/options'),
     platform = require('enyo/platform'),
     roots = require('enyo/roots'),
     utils = require('enyo/utils'),
@@ -1195,9 +1196,8 @@ var Spotlight = module.exports = new function () {
     * @public
     */
     this.onSpotlightFocused = function(oEvent) {
-
         // Accessibility - Set webkit focus to read aria label.
-        if (oEvent.originator) {
+        if (options.accessibility && oEvent.originator) {
             oEvent.originator.setAttribute("tabindex", 0);
             oEvent.originator.focus();
         }

--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -1194,7 +1194,14 @@ var Spotlight = module.exports = new function () {
     * @param {Object} oEvent - The current event.
     * @public
     */
-    this.onSpotlightFocused = function(oEvent) {};
+    this.onSpotlightFocused = function(oEvent) {
+
+        // Accessibility - Set webkit focus to read aria label.
+        if (oEvent.originator) {
+            oEvent.originator.setAttribute("tabindex", 0);
+            oEvent.originator.focus();
+        }
+    };
 
     /**
     * Called when control's focus is blurred.


### PR DESCRIPTION
…ents

According to TV UX for accessibility, it should read label out when
spotlight focused.  The label can be read when control has webkit focus,
so add tabindex='0' and set webkit focus in onSpotlightFocused.

https://jira2.lgsvl.com/browse/ENYO-1129
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>