### PR TITLE
ENYO-1617: Factor Spotlight support out of enyo/VirtualDataRepeater

### DIFF
--- a/lib/VDRSpotlightSupport.js
+++ b/lib/VDRSpotlightSupport.js
@@ -1,0 +1,31 @@
+var
+	kind = require('enyo/kind');
+
+var
+	Spotlight = require('./spotlight');
+
+/**
+* The {@link spotlight/VDRSpotlightSupport} [mixin]{@glossary mixin} adds Spotlight
+* support to {@link enyo.VirtualDataRepeater}. Specifically, it ensures that Spotlight
+* focus is properly removed if the currently focused element is virtualized.
+*
+* Any application or library that uses Spotlight and creates a subkind or instance of
+* {@link enyo.VirtualDataRepeater} with focusable elements inside should mix
+* {@link spotlight/VDRSpotlightSupport} into the subkind or instance.
+*
+* @mixin spotlight/VDRSpotlightSupport
+* @public
+*/
+module.exports = {
+	assignChild: kind.inherit(function (sup) {
+		return function (model, index, child) {
+			var cur = Spotlight.getCurrent();
+
+			if (cur && child === cur && child.model !== model) {
+				Spotlight.unspot();
+			}
+
+			sup.apply(this, arguments);
+		};
+	})
+};


### PR DESCRIPTION
For expediency during initial development, enyo/VirtualDataRepeater
had direct awareness of (and therefore a dependency on) Spotlight.

We now factor this out so that enyo/VirtualDataRepeater knows
nothing of Spotlight, and Spotlight itself provides a mixin
allowing Spotlight awareness to be added to VDR as needed by
library or app code.

ENYO-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)