### PR TITLE
ENYO-1461: Add `preventTap` support

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -146,6 +146,7 @@ module.exports = function (Spotlight) {
     this.onSpotlightFocused = function(oSender, oEvent) {
         var o5WayEvent,
             s5WayEventType,
+            s5WayEventDir,
             o5WayEventOriginator,
             oChildToFocus;
 
@@ -160,6 +161,7 @@ module.exports = function (Spotlight) {
         o5WayEvent = Spotlight.getLast5WayEvent();
         if (o5WayEvent) {
             s5WayEventType = o5WayEvent.type;
+            s5WayEventDir = s5WayEventType.replace('onSpotlight', '').toUpperCase();
             // Containers with `spotlightRememberFocus: false` need to know about
             // the 'original' (non-container) originator of the event, so we pass
             // it around using the `_originator` property
@@ -190,7 +192,7 @@ module.exports = function (Spotlight) {
             if (o5WayEvent && oSender.spotlightRememberFocus === false) {
                 oChildToFocus = Spotlight.NearestNeighbor.getNearestNeighbor(
                     // 5-way direction
-                    s5WayEventType.replace('onSpotlight', '').toUpperCase(),
+                    s5WayEventDir,
                     // The true (non-container) originator of the 5-way event
                     o5WayEventOriginator,
                     // To scope our search to children of the container, we
@@ -202,7 +204,7 @@ module.exports = function (Spotlight) {
                 oChildToFocus = this.getLastFocusedChild(oSender);
             }
             if (oChildToFocus) {
-                Spotlight.spot(oChildToFocus);
+                Spotlight.spot(oChildToFocus, {direction: s5WayEventDir});
             } else {
                 if (s5WayEventType) {
 

--- a/lib/neighbor.js
+++ b/lib/neighbor.js
@@ -282,7 +282,7 @@ module.exports = function (Spotlight) {
                 oSibling = null,
                 oBestMatch = null,
                 nBestMatch = 0,
-                nBestDistance = 0,
+                nBestDistance = sDirection ? 0 : Infinity,
                 nLen = o.length;
 
             for (n = 0; n < nLen; n++) {
@@ -293,26 +293,48 @@ module.exports = function (Spotlight) {
 
                 oBounds2 = oSibling.getAbsoluteBounds();
 
-                // If control is in half plane specified by direction
-                if (_isInHalfPlane(sDirection, oBounds1, oBounds2)) {
-                    // Find control with highest precedence to the direction
-                    nPrecedence = _getAdjacentControlPrecedence(sDirection, oBounds1, oBounds2);
-                    if (nPrecedence > nBestMatch) {
-                        nBestMatch = nPrecedence;
-                        oBestMatch = oSibling;
-                        nBestDistance = _getCenterToCenterDistance(oBounds1, oBounds2);
-                    } else if (nPrecedence == nBestMatch) {
-                        nDistance = _getCenterToCenterDistance(oBounds1, oBounds2);
-                        if (nBestDistance > nDistance) {
+                if (sDirection) {
+                    // If control is in half plane specified by direction
+                    if (_isInHalfPlane(sDirection, oBounds1, oBounds2)) {
+                        // Find control with highest precedence to the direction
+                        nPrecedence = _getAdjacentControlPrecedence(sDirection, oBounds1, oBounds2);
+                        if (nPrecedence > nBestMatch) {
                             nBestMatch = nPrecedence;
                             oBestMatch = oSibling;
-                            nBestDistance = nDistance;
+                            nBestDistance = _getCenterToCenterDistance(oBounds1, oBounds2);
+                        } else if (nPrecedence == nBestMatch) {
+                            nDistance = _getCenterToCenterDistance(oBounds1, oBounds2);
+                            if (nBestDistance > nDistance) {
+                                nBestMatch = nPrecedence;
+                                oBestMatch = oSibling;
+                                nBestDistance = nDistance;
+                            }
                         }
                     }
                 }
+                else {
+                    nDistance = _getCenterToCenterDistance(oBounds1, oBounds2);
+                    if (nDistance < nBestDistance) {
+                        nBestDistance = nDistance;
+                        oBestMatch = oSibling;
+                    }
+                }
+
             }
             return oBestMatch;
         };
+
+    // TODO: Deprecate both `getNearestPointerNeighbor()` and `getNearestNeighbor()`
+    //       and replace with a new `getNearestNeighbor()` in Spotlight. Motivation:
+    //
+    //         * Create a single unified API for finding the neighbor of an arbitrary
+    //           Control, the currently focused Control, the location of the pointer,
+    //           an arbitrary point, etc.
+    //         
+    //         * Remove Spotlight dependency from NearestNeighbor module, keeping
+    //           NearestNeighbor focused on the basic algorithm and decoupled from
+    //           details like container vs. not, the existence of 'last focused
+    //           child', etc.
 
     /**
     * Gets the nearest neighbor of the pointer.

--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -323,6 +323,7 @@ var Spotlight = module.exports = new function () {
                 _o5WaySelectTarget = null;
             }
 
+            // If there's a defaultDisappear control, pick that
             var oControl = _oDefaultDisappear;
 
             // Nothing is set in defaultSpotlightDisappear
@@ -339,13 +340,9 @@ var Spotlight = module.exports = new function () {
                     _oCurrent = null;
                     return;
                 }
-
-                // Prevent unmanageable case when _oCurrent is undefined
-                // if (!oControl) { throw 'SPOTLIGHT: No spottable controls found'; }
             }
 
-            // Spot first child of the app
-            _oThis.spot(oControl);
+            _oThis.spot(oControl, {focusType: 'default'});
         },
 
         /**
@@ -471,7 +468,7 @@ var Spotlight = module.exports = new function () {
             _oLast5WayEvent = oEvent;
 
             if (oControl) {
-                _oThis.spot(oControl, sDirection);
+                _oThis.spot(oControl, {direction: sDirection});
             } else {
                 if (_oThis.Accelerator.isAccelerating()) {
                     _oThis.Accelerator.cancel();
@@ -480,9 +477,9 @@ var Spotlight = module.exports = new function () {
 
                     // Reached the end of spottable world
                     if (!oParent || oParent.spotlightModal) {
-                        _oThis.spot(_oLastControl);
+                        _spotLastControl();
                     } else {
-                        _oThis.spot(oParent, sDirection);
+                        _oThis.spot(oParent, {direction: sDirection});
                     }
                 }
             }
@@ -678,10 +675,19 @@ var Spotlight = module.exports = new function () {
         */
         _spotLastControl = function() {
             if (_oThis.isSpottable(_oLastControl)) {
-                _oThis.spot(_oLastControl);
+                return _oThis.spot(_oLastControl, {focusType: 'default'});
             } else {
-                _oThis.spot(_oThis.getFirstChild(_oRoot));
+                return _spotFirstChild();
             }
+        },
+
+        /**
+        * Spots the first child of the Spotlight root.
+        *
+        * @private
+        */
+        _spotFirstChild = function() {
+            return _oThis.spot(_oThis.getFirstChild(_oRoot), {focusType: 'default'});
         },
 
         /**
@@ -692,14 +698,16 @@ var Spotlight = module.exports = new function () {
         * @private
         */
         _spotNearestToPointer = function(oEvent) {
-            var oNearest = _oThis.
-            NearestNeighbor.
-            getNearestPointerNeighbor(_oRoot,
-                _getSpotDirection(oEvent),
-                _nPrevClientX,
-                _nPrevClientY);
+            var sDir = oEvent && _getSpotDirection(oEvent),
+                oNearest = _oThis.
+                    NearestNeighbor.
+                    getNearestPointerNeighbor(_oRoot,
+                        sDir,
+                        _nPrevClientX,
+                        _nPrevClientY
+                    );
             if (oNearest) {
-                _oThis.spot(oNearest);
+                _oThis.spot(oNearest, {direction: sDir});
             } else {
                 _spotLastControl();
             }
@@ -740,7 +748,7 @@ var Spotlight = module.exports = new function () {
                             this.setPointerMode( window.PalmSystem.cursor.visibility );
                         }
                         // Whenever app goes to foreground, refocus on last focused control
-                        this.spot(this.getLastControl());
+                        _spotLastControl();
                     }
                     break;
                 case 'blur':
@@ -929,7 +937,7 @@ var Spotlight = module.exports = new function () {
                 ) {
                     return;
                 } // ignore consecutive mouse moves on same target
-                this.spot(oTarget, null, true);
+                this.spot(oTarget, {focusType: 'point'});
                 _oLastMouseMoveTarget = oTarget;
 
             } else {
@@ -954,7 +962,7 @@ var Spotlight = module.exports = new function () {
                 this.unfreeze();
                 this.unspot();
                 if (oTarget) {
-                    this.spot(oTarget, null, true);
+                    this.spot(oTarget, {focusType: 'point'});
                 }
                 return true;
             }
@@ -1192,7 +1200,7 @@ var Spotlight = module.exports = new function () {
                     oEvent.originator);
             }
         } else {
-            return this.spot(aChildren[0]);
+            return this.spot(aChildren[0], {focusType: 'default'});
         }
     };
 
@@ -1251,16 +1259,14 @@ var Spotlight = module.exports = new function () {
         _bInitialized = true;
 
         if (_oDefaultControl) {
-            if (this.spot(_oDefaultControl)) {
+            if (this.spot(_oDefaultControl, {focusType: 'default'})) {
                 return true;
             }
         }
 
-        if (this.spot(this.getFirstChild(_oRoot))) {
+        if (_spotFirstChild()) {
             return true;
         }
-        //_warn('Spotlight initialization failed.
-        // No spottable children found in ' + _oRoot.toString());
     };
 
     /**
@@ -1472,11 +1478,35 @@ var Spotlight = module.exports = new function () {
     /**
     * Dispatches focus event to the control or its first spottable child.
     *
-    * @param {Object} oControl - The control to be focused.
+    * @param {enyo.Control} oControl - The control to be focused.
+    * @param {Object} info - Information about the nature of the focus operation.
+    *   The properties of the `info` object are utilized by the logic in the `spot()`
+    *   and included in the payload of the resulting `onSpotlightFocus` event. The
+    *   `info` parameter is intended primarily for Spotlight's internal use; application
+    *   code should generally not need to use it.
     * @return {Boolean} - `true` if control was focused successfully; otherwise, `false`.
     * @public
     */
-    this.spot = function(oControl, sDirection, bWasPoint) {
+    this.spot = function(oControl, info) {
+        // Support for legacy 2nd and 3rd arguments (sDirection, bWasPoint)
+        if (arguments.length > 2 || typeof arguments[1] === 'string') {
+            _warn('Spotlight.spot(): Agruments have changed. See docs.');
+            info = {
+                direction: arguments[1],
+                focusType: arguments[2] ? 'point' : (arguments[1] ? '5-way' : 'explicit')
+            };
+        }
+
+        info = info || {};
+
+        if (info.direction) {
+            info.focusType = '5-way';
+            // Support legacy 'dir' property
+            info.dir = info.direction;
+        }
+        else if (!info.focusType) {
+            info.focusType = 'explicit';
+        }
 
         // If spotlight is not yet initialized
         // Preserve control to be spotted on initialize
@@ -1515,7 +1545,7 @@ var Spotlight = module.exports = new function () {
             }
 
             // When the user calls spot programmatically in pointer mode, we don't actually
-            if (this.getPointerMode() && !bWasPoint) {
+            if (this.getPointerMode() && info.focusType === 'explicit') {
                 this.unspot();
 
                 // spot; instead we just unspot and set up the _oLastControl
@@ -1527,9 +1557,7 @@ var Spotlight = module.exports = new function () {
             } else {
 
                 // Dispatch focus to new control
-                _dispatchEvent('onSpotlightFocus', {
-                    dir: sDirection
-                }, oControl);
+                _dispatchEvent('onSpotlightFocus', info, oControl);
             }
             return true;
         }

--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -139,6 +139,17 @@ var Spotlight = module.exports = new function () {
         */
        _o5WaySelectTarget = null,
 
+       /**
+        * When the user presses Enter to perform a Spotlight select, we keep track
+        * of the original keydown event, since the event exposes an API allowing the
+        * developer to prevent the tap that normally fires on Spotlight select. We
+        * check the cached event on keyup to see whether the tap has been prevented.
+        * @type {Object}
+        * @default null
+        * @private
+        */
+       _oDownEvent = null,
+
         /**
         * In verbose mode, Spotlight prints 1) Current 2) Pointer mode change to `enyo.log`.
         * @type {Boolean}
@@ -308,6 +319,7 @@ var Spotlight = module.exports = new function () {
 
             if (_oCurrent === _o5WaySelectTarget) {
                 gesture.drag.endHold();
+                _oDownEvent = null;
                 _o5WaySelectTarget = null;
             }
 
@@ -787,6 +799,11 @@ var Spotlight = module.exports = new function () {
             };
         };
         gesture.drag.prepareHold(oEvent);
+        if (oEvent.keyCode === 13) {
+            oEvent.preventTap = function () {
+                this._tapPrevented = true;
+            };
+        }
         switch (oEvent.type) {
             case 'keydown':
                 return _dispatchEvent('onSpotlightKeyDown', oEvent);
@@ -1111,8 +1128,10 @@ var Spotlight = module.exports = new function () {
         switch (oEvent.keyCode) {
             case 13:
                 if (oEvent.originator === _o5WaySelectTarget) {
+                    oEvent._tapPrevented = oEvent._tapPrevented || _oDownEvent._tapPrevented;
                     ret = _dispatchEvent('onSpotlightSelect', oEvent);
                     gesture.drag.endHold();
+                    _oDownEvent = null;
                 }
                 _o5WaySelectTarget = null;
         }
@@ -1127,6 +1146,7 @@ var Spotlight = module.exports = new function () {
                 if (!this.Accelerator.isAccelerating()) {
                     _o5WaySelectTarget = oEvent.originator;
                     gesture.drag.beginHold(oEvent);
+                    _oDownEvent = oEvent;
                 }
                 return true;
             case 37:
@@ -1160,12 +1180,17 @@ var Spotlight = module.exports = new function () {
 
         aChildren = this.getChildren(oEvent.originator);
         if (aChildren.length === 0) {
-            return _dispatchEvent('tap', {
-                    customEvent: false,
-                    preventDefault: utils.nop,
-                    fromSpotlight: true
-                },
-                oEvent.originator);
+            if (oEvent._tapPrevented) {
+                return true;
+            }
+            else {
+                return _dispatchEvent('tap', {
+                        customEvent: false,
+                        preventDefault: utils.nop,
+                        fromSpotlight: true
+                    },
+                    oEvent.originator);
+            }
         } else {
             return this.spot(aChildren[0]);
         }

--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -1544,14 +1544,17 @@ var Spotlight = module.exports = new function () {
                 return true;
             }
 
-            // When the user calls spot programmatically in pointer mode, we don't actually
-            if (this.getPointerMode() && info.focusType === 'explicit') {
+            // In pointer mode, we only spot in response to pointer events
+            // (where focusType === 'point'). For other types of focus requests
+            // (e.g. an explicit call to `spot()` or a request from within
+            // Spotlight to focus a default Control), we just unspot and set
+            // the _oLastControl variable, which is used to
+            // set focus when re-entering 5-way mode.
+            if (this.getPointerMode() && info.focusType !== 'point') {
                 this.unspot();
 
-                // spot; instead we just unspot and set up the _oLastControl
                 _oLastControl = oControl;
 
-                // used when resuming 5-way focus on an arrow key press
                 _oLastMouseMoveTarget = null;
                 _log("Spot called in pointer mode; 5-way will resume from: " + oControl.id);
             } else {


### PR DESCRIPTION
By default, Spotlight fires a synthetic `ontap` event (in
addition to an `onSpotlightSelect` event) when an element is
selected in 5-way mode. This is because Spotlight selection is
semantically equivalent to tapping; controls should generally
take the same action when Spotlight-selected as they do when
tapped.

Library and app developers can therefore generally handle both
cases with a single tap handler, rather than separate handlers
for `ontap` and `onSpotlightSelect`.

However, until now, Spotlight has not respected enyo/gesture's
`preventTap()` method, which allows library or app code to
prevent a tap from occurring as needed. `preventTap()`
is exposed on `up` and `down` events.

In this change, we modify Spotlight to respect `preventTap()`.
We do so by adding the `preventTap()` method to the
`onSpotlightKeyUp` and `onSpotlightKeyDown` events, and
checking to see whether `preventTap()` has been invoked before
we fire the synthetic `ontap` event.

I opted not to prevent the `onSpotlightSelect` event itself, but
just to prevent the `ontap` event. If we encounter a situation
where this is a problem, we can consider preventing both events
in response to the invocation of `preventTap()` or adding an
equivalent `preventSpotlightSelect()` method.

This change was motivated by a use case in
moonstone/NewPagingControl, where we wanted to prevent a tap from
occurring at the end of a hold gesture.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)