### PR TITLE
BHV-21598: onholdpulse event is not stop when pressing 5way while hol…

### DIFF
--- a/enyo.Spotlight.js
+++ b/enyo.Spotlight.js
@@ -195,7 +195,14 @@ enyo.Spotlight = new function() {
         * @default 0
         * @private
         */
-        _nIgnoredKeyDown = 0;
+        _nIgnoredKeyDown = 0,
+
+        /**
+        * @type {Number}
+        * @default null
+        * @private
+        */
+        _lastSpotlightKeyDown = null;
 
         /**
         * @constant
@@ -1082,7 +1089,12 @@ enyo.Spotlight = new function() {
         return ret;
     };
     this.onSpotlightKeyDown = function(oEvent) {
-
+       
+        if(_lastSpotlightKeyDown != oEvent.keyCode){
+            enyo.gesture.drag.endHold();  
+        }
+        _lastSpotlightKeyDown = oEvent.keyCode;
+        
         switch (oEvent.keyCode) {
             case 13:
                 if (!enyo.Spotlight.Accelerator.isAccelerating()) {


### PR DESCRIPTION
…ding ok button

Issue:
Press okay button to start holdPulse. Press 4way button with okay button pressed. Then release okay button.
The onholdpulse event is not stop on TV. Because MICOM driver doesn't send key up event for the first key release.

FIx:
Cancel hold pulse right away when other key press event comes.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com