### PR TITLE
BHV-21598: onholdpulse event is not stop when pressing 5way while hol…

### DIFF
--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -226,7 +226,14 @@ var Spotlight = module.exports = new function () {
         * @default 0
         * @private
         */
-        _nIgnoredKeyDown = 0;
+        _nIgnoredKeyDown = 0,
+
+        /**
+        * @type {Number}
+        * @default null
+        * @private
+        */
+        _lastSpotlightKeyDown = null;
 
         /**
         * @constant
@@ -1124,6 +1131,11 @@ var Spotlight = module.exports = new function () {
         return ret;
     };
     this.onSpotlightKeyDown = function(oEvent) {
+       
+        if(_lastSpotlightKeyDown != oEvent.keyCode){
+            gesture.drag.endHold();  
+        }
+        _lastSpotlightKeyDown = oEvent.keyCode;
 
         switch (oEvent.keyCode) {
             case 13:


### PR DESCRIPTION
…ding ok button

Issue:
Press okay button to start holdPulse. Press 4way button with okay button pressed. Then release okay button.
The onholdpulse event is not stop on TV. Because MICOM driver doesn't send key up event for the first key release.

FIx:
Cancel hold pulse right away when other key press event comes.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com