### PR TITLE
ENYO-1684: null access error is occurred in enyo.dom.compareDocumentP…

### DIFF
--- a/enyo.Spotlight.Container.js
+++ b/enyo.Spotlight.Container.js
@@ -232,7 +232,7 @@ enyo.Spotlight.Container = new function() {
                 } else {
                     from = from.parent;
                 }
-            } while (from && from.hasNode());
+            } while (from);
         }
 
         if(focusedControl) {

--- a/enyo.Spotlight.Container.js
+++ b/enyo.Spotlight.Container.js
@@ -223,6 +223,11 @@ enyo.Spotlight.Container = new function() {
 
             // find common ancestor
             do {
+                // skip over tagless Controls (e.g. enyo/ScrollStrategy)
+                if (!from.hasNode()) {
+                    from = from.parent;
+                    continue;
+                }
                 position = enyo.dom.compareDocumentPosition(to, from.hasNode());
                 if(position & 8) {  // 8 == 'contains'
                     enyo.Spotlight.Util.dispatchEvent('onSpotlightContainerLeave', {

--- a/enyo.Spotlight.Container.js
+++ b/enyo.Spotlight.Container.js
@@ -216,7 +216,7 @@ enyo.Spotlight.Container = new function() {
     };
 
     this.fireContainerEvents = function (blurredControl, focusedControl) {
-        if(blurredControl) {
+        if(blurredControl && blurredControl.hasNode()) {
             var to = focusedControl.hasNode(),
                 from = blurredControl,
                 position = 0;
@@ -232,7 +232,7 @@ enyo.Spotlight.Container = new function() {
                 } else {
                     from = from.parent;
                 }
-            } while (from);
+            } while (from && from.hasNode());
         }
 
         if(focusedControl) {


### PR DESCRIPTION
…osition() sometimes

Issue:
This issue happens when the spotlight is change current. But, the last focused item is already did tearDownRender or has no node.
The spotlight container is calling position = dom.compareDocumentPosition(to, from.hasNode()); with false for second argument.

Fix:
Checking

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com