### PR TITLE
ENYO-1684: null access error is occurred in enyo.dom.compareDocumentP…

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -257,13 +257,18 @@ module.exports = function (Spotlight) {
     };
 
     this.fireContainerEvents = function (blurredControl, focusedControl) {
-        if(blurredControl) {
+        if(blurredControl && blurredControl.hasNode()) {
             var to = focusedControl.hasNode(),
                 from = blurredControl,
                 position = 0;
 
             // find common ancestor
             do {
+                // skip over tagless Controls (e.g. enyo/ScrollStrategy)
+                if (!from.hasNode()) {
+                    from = from.parent;
+                    continue;
+                }
                 position = dom.compareDocumentPosition(to, from.hasNode());
                 if(position & 8) {  // 8 == 'contains'
                     Spotlight.Util.dispatchEvent('onSpotlightContainerLeave', {


### PR DESCRIPTION
…osition() sometimes (2.6-dev)

- Issue:
from.hasNode() can return false in case of enyo/ScrollStrategy.

- Fix:
We skip tagless Controls.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com