### PR TITLE
ENYO-1689: Accessibility: migration accessibilityDisabled to enyo 2.6

### DIFF
--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -1193,8 +1193,12 @@ var Spotlight = module.exports = new function () {
     this.onSpotlightFocused = function(oEvent) {
         // Accessibility - Set webkit focus to read aria label.
         if (options.accessibility && oEvent.originator) {
-            oEvent.originator.setAttribute("tabindex", 0);
-            oEvent.originator.focus();
+            if (oEvent.originator.accessibilityDisabled) {
+                oEvent.originator.setAttribute("tabindex", null);
+            } else {
+                oEvent.originator.setAttribute("tabindex", 0);
+                oEvent.originator.focus();
+            }
         }
     };
 


### PR DESCRIPTION
Supporting accessibilityDisabled for spotlight focus.
If accessibilityDisabled is true, set tabindex as null considering
dynamic change.

https://jira2.lgsvl.com/browse/ENYO-1689
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>