### PR TITLE
ENYO-1330: add getFarthestNeighbor for supporting new PageUp/Down ux

### DIFF
--- a/lib/neighbor.js
+++ b/lib/neighbor.js
@@ -369,6 +369,7 @@ module.exports = function (Spotlight) {
                 oBounds2,
                 nPrecedence,
                 nDistance,
+                nDistanceToEdge,
                 oSibling = null,
                 oBestMatch = null,
                 nBestMatch = 0,
@@ -482,7 +483,7 @@ module.exports = function (Spotlight) {
         oBounds = oControl.getAbsoluteBounds();
 
         return _calculateNearestNeighbor(oCandidates, sDirection, oBounds, oControl);
-    };
+    },
 
     /**
     * Gets the farthest neighbor of a control.

--- a/lib/neighbor.js
+++ b/lib/neighbor.js
@@ -61,7 +61,7 @@ module.exports = function (Spotlight) {
                 bBottom = oBounds.top + oBounds.height <= oTargetBounds.top + oTargetBounds.height;
 
             return bTop && bLeft && bRight && bBottom;
-        }
+        },
 
         /**
         * Checks to see which control has higher precedence for spottability.

--- a/lib/neighbor.js
+++ b/lib/neighbor.js
@@ -46,6 +46,24 @@ module.exports = function (Spotlight) {
         },
 
         /**
+        * Checks to see whether the control is in the target bounds.
+        *
+        * @param  {String} sDirection - The direction of acceleration.
+        * @param  {Object} oBounds - control's bounds.
+        * @param  {Object} oTargetBounds - target bounds.
+        * @returns {Boolean}
+        * @private
+        */
+        _isInTargetBounds = function(sDirection, oBounds, oTargetBounds) {
+            var bTop = oBounds.top >= oTargetBounds.top,
+                bLeft = oBounds.left >= oTargetBounds.left,
+                bRight = oBounds.left + oBounds.width <= oTargetBounds.left + oTargetBounds.width,
+                bBottom = oBounds.top + oBounds.height <= oTargetBounds.top + oTargetBounds.height;
+
+            return bTop && bLeft && bRight && bBottom;
+        }
+
+        /**
         * Checks to see which control has higher precedence for spottability.
         *
         * @param  {String} sDirection - The direction of acceleration.
@@ -165,6 +183,28 @@ module.exports = function (Spotlight) {
                 x: x2,
                 y: y2
             }];
+        },
+
+        /**
+        * Retrieves the distance between control's edge and target's edge.
+        *
+        * @param  {String} sDirection - The direction of acceleration.
+        * @param  {Object} oBounds - control's bounds.
+        * @param  {Object} oTargetBounds - target's bounds.
+        * @returns {Number}
+        * @private
+        */
+        _getDistanceToEdge = function(sDirection, oBounds, oTargetBounds) {
+            switch (sDirection) {
+                case 'UP':
+                    return oBounds.top + oBounds.height - oTargetBounds.top;
+                case 'DOWN':
+                    return oTargetBounds.top + oTargetBounds.height - oBounds.top;
+                case 'LEFT':
+                    return oBounds.left + oBounds.width - oTargetBounds.left;
+                case 'RIGHT':
+                    return oTargetBounds.left + oTargetBounds.width - oBounds.left;
+            }
         },
 
         /**
@@ -314,6 +354,64 @@ module.exports = function (Spotlight) {
             return oBestMatch;
         };
 
+        /**
+        * Calculates nearest neighbor based on bounds and acceleration direction.
+        *
+        * @param  {Object} o - Object used to determine if it is a neighbor.
+        * @param  {Number} sDirection - The direction of acceleration
+        * @param  {Number} oBounds1 - Originating bounds.
+        * @param  {Number} oControl - The current control.
+        * @returns {Number}
+        * @private
+        */
+        _calculateFarthestNeighbor = function(o, sDirection, oBounds1, oControl, oTargetBounds) {
+            var n,
+                oBounds2,
+                nPrecedence,
+                nDistance,
+                oSibling = null,
+                oBestMatch = null,
+                nBestMatch = 0,
+                nBestDistanceToEdge = 9999,
+                nBestDistance = 0,
+                nLen = o.length;
+
+            for (n = 0; n < nLen; n++) {
+                oSibling = o[n];
+                if (oControl && oSibling === oControl) {
+                    continue;
+                }
+
+                oBounds2 = oSibling.getAbsoluteBounds();
+
+                // If control is in half plane specified by direction
+                if (_isInHalfPlane(sDirection, oBounds1, oBounds2) && _isInTargetBounds(sDirection, oBounds2, oTargetBounds)) {
+                    // Find control with highest precedence to the direction
+                    nDistanceToEdge = _getDistanceToEdge(sDirection, oBounds2, oTargetBounds);
+                    nPrecedence = _getAdjacentControlPrecedence(sDirection, oBounds1, oBounds2);
+                    if (nDistanceToEdge < nBestDistanceToEdge) {
+                        nBestMatch = nPrecedence;
+                        oBestMatch = oSibling;
+                        nBestDistanceToEdge = nDistanceToEdge;
+                        nBestDistance = _getCenterToCenterDistance(oBounds1, oBounds2);
+                    } else if (nDistanceToEdge == nBestDistanceToEdge && nPrecedence > nBestMatch) {
+                        nBestMatch = nPrecedence;
+                        oBestMatch = oSibling;
+                        nBestDistanceToEdge = nDistanceToEdge;
+                        nBestDistance = _getCenterToCenterDistance(oBounds1, oBounds2);
+                    } else if (nPrecedence == nBestMatch) {
+                        nDistance = _getCenterToCenterDistance(oBounds1, oBounds2);
+                        if (nBestDistance > nDistance) {
+                            nBestMatch = nPrecedence;
+                            oBestMatch = oSibling;
+                            nBestDistance = nDistance;
+                        }
+                    }
+                }
+            }
+            return oBestMatch;
+        };
+
     /**
     * Gets the nearest neighbor of the pointer.
     *
@@ -356,16 +454,16 @@ module.exports = function (Spotlight) {
 
         // Check to see if default direction is specified
         oNeighbor = Spotlight.Util.getDefaultDirectionControl(sDirection, oControl);
-		if (oNeighbor) {
-			if (Spotlight.isSpottable(oNeighbor)) {
-				return oNeighbor;
-			} else {
-				oNeighbor = Spotlight.getFirstChild(oNeighbor);
-				if (oNeighbor && Spotlight.isSpottable(oNeighbor)) { 
-					return oNeighbor;
-				}
-			}
-		}
+        if (oNeighbor) {
+            if (Spotlight.isSpottable(oNeighbor)) {
+                return oNeighbor;
+            } else {
+                oNeighbor = Spotlight.getFirstChild(oNeighbor);
+                if (oNeighbor && Spotlight.isSpottable(oNeighbor)) { 
+                    return oNeighbor;
+                }
+            }
+        }
 
         // If default control in the direction of navigation is not specified, calculate it
 
@@ -384,5 +482,47 @@ module.exports = function (Spotlight) {
         oBounds = oControl.getAbsoluteBounds();
 
         return _calculateNearestNeighbor(oCandidates, sDirection, oBounds, oControl);
+    };
+
+    /**
+    * Gets the farthest neighbor of a control.
+    *
+    * @param  {String} sDirection - The direction in which to spot the next control.
+    * @param  {Object} oControl - The control whose farthest neighbor is to be
+    * determined.
+    * @param  {Object} oTargetBounds - The bounds(area) in which to find farthest neighbor.
+    * @returns {Object} The farthest neighbor of the control.
+    * @public
+    */
+
+    this.getFarthestNeighbor = function(sDirection, oControl, oTargetBounds) {
+        var oNeighbor,
+            oCandidates,
+            oBounds;
+
+        sDirection = sDirection.toUpperCase();
+        oControl = oControl || Spotlight.getCurrent();
+
+        // Check to see if default direction is specified
+        oNeighbor = Spotlight.Util.getDefaultDirectionControl(sDirection, oControl);
+        if (oNeighbor) {
+            return null;
+        }
+
+        // If default control in the direction of navigation is not specified, calculate it
+
+        // If we've been passed a root, find the best match among its children;
+        // otherwise, find the best match among siblings of the reference control
+        oCandidates = Spotlight.getSiblings(oControl).siblings;
+
+        // If the control is container, the nearest neighbor is calculated based on the bounds
+        // of last focused child of container.
+        if (Spotlight.isContainer(oControl)) {
+            oControl = Spotlight.Container.getLastFocusedChild(oControl) || oControl;
+        }
+
+        oBounds = oControl.getAbsoluteBounds();
+
+        return _calculateFarthestNeighbor(oCandidates, sDirection, oBounds, oControl, oTargetBounds);
     };
 };


### PR DESCRIPTION
## Issue
After the scrolling completes following by PageUp/Down key, the top item in the scroll frame does not get re-spotted.

## Fix
Update PageUp/Down key handing based on description of new behavior (in ENYO-1330)
For calculate next spotted item, add getFarthestNeighbor method to the neighbor.js file

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com