### PR TITLE
ENYO-2032: Accessibility: popup position is wrong.

### DIFF
--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -1226,7 +1226,7 @@ var Spotlight = module.exports = new function () {
     this.onSpotlightFocused = function(oEvent) {
         // Accessibility - Set webkit focus to read aria label.
         if (options.accessibility && oEvent.originator) {
-            if (oEvent.originator.accessibilityDisabled) {
+            if (oEvent.originator.accessibilityDisabled || this.getPointerMode()) {
                 oEvent.originator.setAttribute("tabindex", null);
             } else {
                 oEvent.originator.setAttribute("tabindex", 0);


### PR DESCRIPTION
Accroding to accessibility UX guide, accessibility is only supported on
5 way mode, so we don't set focus on pointer mode.

https://jira2.lgsvl.com/browse/ENYO-2032
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>