### PR TITLE
ENYO-2158: Focus jumps to first visible child when focus move out from datalist

### DIFF
--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -478,7 +478,7 @@ var Spotlight = module.exports = new function () {
 
                     // Reached the end of spottable world
                     if (!oParent || oParent.spotlightModal) {
-                        _spotLastControl('edge');
+                        _spotLastControl({focusType: '5-way bounce'});
                     } else {
                         _oThis.spot(oParent, {direction: sDirection});
                     }
@@ -674,11 +674,13 @@ var Spotlight = module.exports = new function () {
         *
         * @private
         */
-        _spotLastControl = function(focusType) {
+        _spotLastControl = function(info) {
+            var focusType = (info && info.focusType) || 'default';
+
             if (_oThis.isSpottable(_oLastControl)) {
-                return _oThis.spot(_oLastControl, {focusType: focusType ? focusType : 'default'});
+                return _oThis.spot(_oLastControl, {focusType: focusType});
             } else {
-                return _spotFirstChild(focusType);
+                return _spotFirstChild();
             }
         },
 
@@ -687,8 +689,8 @@ var Spotlight = module.exports = new function () {
         *
         * @private
         */
-        _spotFirstChild = function(focusType) {
-            return _oThis.spot(_oThis.getFirstChild(_oRoot), {focusType: focusType ? focusType : 'default'});
+        _spotFirstChild = function() {
+            return _oThis.spot(_oThis.getFirstChild(_oRoot), {focusType: 'default'});
         },
 
         /**

--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -478,7 +478,7 @@ var Spotlight = module.exports = new function () {
 
                     // Reached the end of spottable world
                     if (!oParent || oParent.spotlightModal) {
-                        _spotLastControl();
+                        _spotLastControl('edge');
                     } else {
                         _oThis.spot(oParent, {direction: sDirection});
                     }
@@ -674,11 +674,11 @@ var Spotlight = module.exports = new function () {
         *
         * @private
         */
-        _spotLastControl = function() {
+        _spotLastControl = function(focusType) {
             if (_oThis.isSpottable(_oLastControl)) {
-                return _oThis.spot(_oLastControl, {focusType: 'default'});
+                return _oThis.spot(_oLastControl, {focusType: focusType ? focusType : 'default'});
             } else {
-                return _spotFirstChild();
+                return _spotFirstChild(focusType);
             }
         },
 
@@ -687,8 +687,8 @@ var Spotlight = module.exports = new function () {
         *
         * @private
         */
-        _spotFirstChild = function() {
-            return _oThis.spot(_oThis.getFirstChild(_oRoot), {focusType: 'default'});
+        _spotFirstChild = function(focusType) {
+            return _oThis.spot(_oThis.getFirstChild(_oRoot), {focusType: focusType ? focusType : 'default'});
         },
 
         /**


### PR DESCRIPTION


Issue:
- Focus moves to first visible item when trying to move out from
  datalist.

Fix:
- Give different focusType to _5WayMove case.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>