### PR TITLE
Add `previous` property to `onSpotlightFocus`, `onSpotlightFocused`

### DIFF
--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -407,7 +407,8 @@ var Spotlight = module.exports = new function () {
                 throw 'Attempting to spot not-spottable control: ' + oControl.toString();
             }
 
-            var oExCurrent = _oCurrent;
+            var oExCurrent = _oCurrent,
+                oPrevious = _oLastControl;
 
             // Remove spotlight class and Blur
             _oThis.unspot(oControl);
@@ -434,7 +435,7 @@ var Spotlight = module.exports = new function () {
                 _oLastControl = oControl;
             }
 
-            _dispatchEvent('onSpotlightFocused');
+            _dispatchEvent('onSpotlightFocused', {previous: oPrevious});
 
             _oThis.TestMode.highlight();
 
@@ -1511,6 +1512,8 @@ var Spotlight = module.exports = new function () {
         }
 
         info = info || {};
+
+        info.previous = _oLastControl;
 
         if (info.direction) {
             info.focusType = '5-way';


### PR DESCRIPTION
We (fairly) recently added a `next` property to the
`onSpotlightBlur` event, indicating which element will be focused
next.

We now add a similar `previous` property to `onSpotlightFocus` and
`onSpotlightFocused`.

These properties are intended to let handlers discriminate on the
basis of where focus is coming from / going when implementing
special-case logic.

The `previous` property specifically was useful in refining 5-way
scrolling behavior in Moonstone, to switch between item-at-a-time
and page-at-a-time scrolling depending on where the focus
previously was (see moonstone/Scrollable).

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)