### PR TITLE
ENYO-2229-Marquee rolls unexpectedly when display changes

### DIFF
--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -333,12 +333,8 @@ var Spotlight = module.exports = new function () {
                 // Find first spottable in the app
                 oControl = _oThis.getFirstChild(_oRoot);
                 if (!oControl) {
-                    _unhighlight(_oLastControl);
+                    _oThis.unspot(null);
                     _oLastControl = null;
-                    
-                    _observeDisappearance(false, _oCurrent);
-                    // NULL CASE :(, just like when no spottable children found on init
-                    _oCurrent = null;
                     return;
                 }
             }


### PR DESCRIPTION
When the control disappears, earlier spotlight just removes the
spotlight class on the control. Now 'spotlightBlur' event is also
triggered on the control, if the control disappears.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P <rajyavardhan.p@lge.com>