### PR TITLE
ENYO-2236: Spotlight drop keyup event when there is no focus-able item on screen

### DIFF
--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -1109,7 +1109,7 @@ var Spotlight = module.exports = new function () {
 
         if (_bSuppressSelectOnNextKeyUp) {
             _bSuppressSelectOnNextKeyUp = false;
-            return true;
+            return false;
         }
 
         this.Accelerator.processKey(oEvent, this.onAcceleratedKey, this);


### PR DESCRIPTION
## Issue:
- When there is no focus-able item on screen, and user want to get keyup
  event by Signals. Spotlight blocks onKeyUp event and Signals can not
  get the event..
- Originally it is blocked to block tap event hadling when pressing
  enter on pointer mode.

## Fix:
- Return false on _bSupressSelectionOnNextKeyUp case of onKeyUp.
- This will allow to get onkeyup event from Signals but will not process
  tap when press enter on pointer mode.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>