### PR TITLE
ENYO-2265: Observe and unobserve disappearance for the correct controls.

### DIFF
--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -335,7 +335,7 @@ var Spotlight = module.exports = new function () {
                 if (!oControl) {
                     _unhighlight(_oLastControl);
                     _oLastControl = null;
-                    
+
                     _observeDisappearance(false, _oCurrent);
                     // NULL CASE :(, just like when no spottable children found on init
                     _oCurrent = null;
@@ -1080,7 +1080,7 @@ var Spotlight = module.exports = new function () {
             // Spot first available control on bootstrap
             if (!this.isSpottable(this.getCurrent()) ||
                 // Or does this immediately follow KEY_POINTER_HIDE
-                (!_isTimestampExpired() && !_oLastMouseMoveTarget) || 
+                (!_isTimestampExpired() && !_oLastMouseMoveTarget) ||
                 // Or spot last 5-way control, only if there's not already focus on screen
                 (bWasPointerMode && !_oLastMouseMoveTarget && !this.isFrozen())) {
 
@@ -1709,7 +1709,7 @@ var Spotlight = module.exports = new function () {
     *
     * @public
     */
-    this.unfreeze = function() { 
+    this.unfreeze = function() {
 		_bFrozen = false;
 	};
 

--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -287,15 +287,15 @@ var Spotlight = module.exports = new function () {
 
         /**
         * Gets control specified in `defaultSpotlightDisappear` property
-        * of `_oCurrent`. Gotta get it before it disappears :)
+        * of the specified control. Gotta get it before it disappears :)
         *
         * @param {Object} oControl
         * @private
         */
-        _setDefaultDisappearControl = function() {
+        _setDefaultDisappearControl = function(oControl) {
             _oDefaultDisappear = _oThis.Util.getDefaultDirectionControl(
                 'disappear',
-                _oCurrent
+                oControl
             );
         },
 
@@ -372,7 +372,7 @@ var Spotlight = module.exports = new function () {
                     _onDisappear.isOff = false;
 
                     // Capture defaultSpotlightDisappear control
-                    _setDefaultDisappearControl();
+                    _setDefaultDisappearControl(oControl);
                 }
 
                 // Enough to check in _oCurrent only, no ancestors

--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -421,7 +421,7 @@ var Spotlight = module.exports = new function () {
             // Set observers asynchronously to allow painti to happen faster
             setTimeout(function() {
                 _observeDisappearance(false, oExCurrent);
-                _observeDisappearance(true, _oCurrent);
+                _observeDisappearance(true, oControl);
             }, 1);
 
             _oThis.Container.fireContainerEvents(oExCurrent || _oLastControl, _oCurrent);


### PR DESCRIPTION
### Issue
Because we were effectively async'ing the observing and unobserving of disappearance whenever the currently spotted control changed, if there were a sequence of multiple spots, we could potentially be using an incorrect reference to the controls we were to observe/unobserve, as we would be grabbing the last reference to the controls.

### Fix
We made sure that we utilize the correct reference to the controls by using the local var instead of the global var for the current control. Additionally, we made sure to tweak the `_setDefaultDisappearControl` method such that it attempts to retrieve the default disappear control from the control we are observing, as opposed to the global, current Spotlight control.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>