### PR TITLE
ENYO-2234: Tooltip Does Not Display on Input

### DIFF
--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -1229,7 +1229,7 @@ var Spotlight = module.exports = new function () {
     this.onSpotlightFocused = function(oEvent) {
         // Accessibility - Set webkit focus to read aria label.
         if (options.accessibility && oEvent.originator) {
-            if (oEvent.originator.accessibilityDisabled || this.getPointerMode()) {
+            if (oEvent.originator.accessibilityDisabled || oEvent.accessibilityHandled || this.getPointerMode()) {
                 oEvent.originator.setAttribute("tabindex", null);
             } else {
                 oEvent.originator.setAttribute("tabindex", 0);


### PR DESCRIPTION
### Issue:
Tooltip Does Not Display on Input
### Fix:
Removed code in InputDecoratorAccessibilitySupport::spotlightFocusedHandler that stopped bubbling of the onSpotlightFocused event. That code was added to prevent spotlight accessibility code from incorrectly focusing the input when inputDecorator was spotted. Replaced the stop-bubbling code by adding an accesibilityHandled flag to the event, and having spotlight check for this flag before it calls focus()

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan <krishna.rangarajan@lge.com>