### PR TITLE
fix path to js in gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ gulp.task('jshint', lint);
 
 function lint () {
 	return gulp
-		.src('./lib/**/*.js')
+		.src('./src/**/*.js')
 		.pipe(jshint())
 		.pipe(jshint.reporter(stylish, {verbose: true}))
 		.pipe(jshint.reporter('fail'));


### PR DESCRIPTION
Issue: ENYO-2414
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)