### PR TITLE
Fixes ENYO-2430

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -1,7 +1,6 @@
 var
     dom = require('enyo/dom'),
-    logger = require('enyo/logger'),
-    Component = require('enyo/Component');
+    logger = require('enyo/logger');
 
 /**
 * Provides the Spotlight Container
@@ -289,28 +288,5 @@ module.exports = function (Spotlight) {
                 current: focusedControl
             }, focusedControl);
         }
-    };
-
-    /*
-    Using the hack below to ensure that statically declared Spotlight containers are
-    initialized upon creation. Our previous pass at this used enyo.Control.extend(),
-    which meant it failed to work for Control subkinds whose constructors were created
-    immediately (vs. being deferred). Unfortunately, this caused big problems in webOS,
-    where the "container" app systematically disables the deferral of constructor
-    creation.
-
-    There is some discussion ongoing as to whether we need a nicer mechanism for
-    extending functionality in cases like this (see comments in BHV-15323), but in
-    the meantime we need to proceed with a quick fix for this issue.
-    */
-
-    var originalEnyoComponentCreate = Component.create;
-
-    Component.create = function () {
-        var component = originalEnyoComponentCreate.apply(Component, arguments);
-        if (component.spotlight == 'container') {
-            Spotlight.Container.initContainer(component);
-        }
-        return component;
     };
 };


### PR DESCRIPTION
Instead of changing the tabindex onSpotlightFocused, set any spottable
control with a tabindex of -1 (programmatically focusable) on create.
This required moving the hacky Component.create code from container
to spotlight so we only hacked it once for this lib.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)