### PR TITLE
ENYO-2431: Accessibility: When the focus return to the button from in…

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1249,7 +1249,12 @@ var Spotlight = module.exports = new function () {
     * @param {Object} oEvent - The current event.
     * @public
     */
-    this.onSpotlightBlur = function(oEvent) {};
+    this.onSpotlightBlur = function(oEvent) {
+        // Accessibility - blur focus considering spot back from input or dom having aria-hidden
+        if (options.accessibility && oEvent.originator && oEvent.originator.hasFocus()) {
+                oEvent.originator.blur();
+        }
+    };
 
     /**
     * Initializes Spotlight's flags and root.


### PR DESCRIPTION
…put it does not read.

Issue:
When a button gets spotlight back from Input, there is no readout

Cause:
When spotlight is focused on InputDecorator and dom node having 'aria-hidden'
it doesn't set dom focus on them. Therefore when spotlight moves back to
the button, it has dom focus already.

Fix:
Blur dom focus in onSpotlightBlur.

https://jira2.lgsvl.com/browse/ENYO-2431
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>