### PR TITLE
ENYO-1742: Adding handler for webOSMouse event on Spotlight.

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1288,6 +1288,23 @@ var Spotlight = module.exports = new function () {
     };
 
     /**
+    * Called when pointer move between floating style apps.
+    *
+    * @method
+    * @param {Object} oEvent - The current event.
+    * @public
+    */
+	this.onwebOSMouse = function(oEvent) {
+		if (!oEvent || !oEvent.detail) return;
+		if (oEvent.detail.type == 'Leave') {
+			// webOSMouse event comes only when pointer mode
+			this.setPointerMode(false);
+			this.unspot();
+			this.setPointerMode(true);
+		}
+	};
+
+    /**
     * Determines whether Spotlight has been initialized (i.e., it has `_oCurrent` and
     * `last5waycontrol`).
     *


### PR DESCRIPTION
Issue:
When floating app is getting pointer, foreground app doesn't know about
mouse leave. So, the foregrund app doesn't un-highlight focus when mouse
move to floating app. This resulting in dual focus issue.

Fix:
Add webOS specific event, webOSMouse, to let app know mouse leave and
enter.
This event is fired when QT::Leave and QT::Enter event comes.
We hook this event in Events.js and push that to Spotlight lib for
dual focus handling.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>