### PR TITLE
Fixes ENYO-2431

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1233,8 +1233,13 @@ var Spotlight = module.exports = new function () {
         // Accessibility - Set focus to read aria label.
         // Do not focus labels (e.g. moonstone/InputDecorator) since the default behavior is to
         // transfer focus to its internal input.
-        if (options.accessibility && !this.getPointerMode() && c && !c.accessibilityDisabled && c.tag != 'label') {
-            c.focus();
+        if (options.accessibility && !this.getPointerMode()) {
+            if (c && !c.accessibilityDisabled && c.tag != 'label') {
+                c.focus();
+            }
+            else if (document.activeElement) {
+                document.activeElement.blur();
+            }
         }
     };
 


### PR DESCRIPTION
If spotlight alternates between a spottable non-label and a label or
control with accessibility disabled, focus isn't changed when returning
to the non-label because it wasn't set to the label when it was
spotted. So, if the spotted control can't receive focus and there is a
document.activeElement, blur it so it can receive focus again.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)