### PR TITLE
ENYO-1742: unspot on webOSMouse leave

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -746,6 +746,14 @@ var Spotlight = module.exports = new function () {
         // Events only processed when Spotlight initialized with a root
         if (this.isInitialized()) {
             switch (oEvent.type) {
+                case 'webOSMouse':
+                    if (oEvent && oEvent.detail && oEvent.detail.type == 'Leave') {
+                        // webOSMouse event comes only when pointer mode
+                        this.setPointerMode(false);
+                        this.unspot();
+                        this.setPointerMode(true);
+                    }
+                    break;
                 case 'focus':
                     if (oEvent.target === window) {
                         // Update pointer mode from cursor visibility platform API


### PR DESCRIPTION
Issue:
When floating app is getting pointer, foreground app doesn't know about
mouse leave. So, the foregrund app doesn't un-highlight focus when mouse
move to floating app. This resulting in dual focus issue.

Fix:
Add webOS specific event, webOSMouse, to let app know mouse leave and
enter. This event is fired when QT::Leave and QT::Enter event comes.
We directly dispatch this event in enyo-webos index.js.
And, force unspot when webOSMouse leave event comes.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>