### PR TITLE
ENYO-2524: Fallback when default spotlight control is outside of container

### DIFF
--- a/src/neighbor.js
+++ b/src/neighbor.js
@@ -378,7 +378,7 @@ module.exports = function (Spotlight) {
 
         // Check to see if default direction is specified
         oNeighbor = Spotlight.Util.getDefaultDirectionControl(sDirection, oControl);
-		if (oNeighbor) {
+		if (oNeighbor && (!oRoot || oNeighbor.isDescendantOf(oRoot))) {
 			if (Spotlight.isSpottable(oNeighbor)) {
 				return oNeighbor;
 			} else {


### PR DESCRIPTION
Issue:
Panel and expandable drawer is both spotlight 'container'. And back
button is have defaultSpotlightDown control as panels.
When pressing down button from 'back button' and entering focus into
container, o5WayEventOriginator is always back button.
Regardless of oSender, getNearestNeighbor is find neighbor from back
button which is right behavior.
But, when oSender is expandable drawer the result of getNearestNeighbor
should not be outside of drawer.

Fix:
My proposal on this issue is fallback normal routine when
getDefaultDirectionControl returns control outside of oRoot (drawer in
problem case).

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>