### PR TITLE
ENYO-2530: Focus move to breadcrumb when press left on panel item

### DIFF
--- a/src/neighbor.js
+++ b/src/neighbor.js
@@ -45,6 +45,11 @@ module.exports = function (Spotlight) {
             }
         },
 
+        _isContain = function(oBounds1, oBounds2) {
+            return (oBounds1.top <= oBounds2.top) && (oBounds1.top + oBounds1.height >= oBounds2.top + oBounds2.height) &&
+                (oBounds1.left <= oBounds2.left) && (oBounds1.left + oBounds1.width >= oBounds2.left + oBounds2.width);
+        },
+
         /**
         * Checks to see which control has higher precedence for spottability.
         *
@@ -309,6 +314,12 @@ module.exports = function (Spotlight) {
                                 oBestMatch = oSibling;
                                 nBestDistance = nDistance;
                             }
+                        }
+                    } else {
+                        // Short sircuit for getNearestPointerNeighbor
+                        if (!oControl && _isContain(oBounds2, oBounds1)) {
+                            oBestMatch = oSibling;
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Issue:
When we press left key without move mouse just after panel transition by
mouse click (Still there is no focus), Spotlight neighbor routine is
drop half plane from the mouse point.
So, focus move to breadcrumb even if there is focusable item under the
mouse.

Fix:
When _calculateNearestNeighbor called from getNearestPointerNeighbor,
oControl is not passed. So, filter out contains case here only when
called from getNearestPointerNeighbor .

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi kunmyon.choi@lge.com
