### PR TITLE
ENYO-2521: Add spotlightPrecedence option handler

### DIFF
--- a/src/neighbor.js
+++ b/src/neighbor.js
@@ -54,9 +54,9 @@ module.exports = function (Spotlight) {
         * @returns {Number}
         * @private
         */
-        _getAdjacentControlPrecedence = function(sDirection, oBounds1, oBounds2) {
+        _getAdjacentControlPrecedence = function(sDirection, oBounds1, oBounds2, oEvent) {
             var oPoints = _getAdjacentControlPoints(sDirection, oBounds1, oBounds2);
-            return _getPrecedenceValue(oPoints, sDirection);
+            return _getPrecedenceValue(oPoints, sDirection, oEvent);
         },
 
         /**
@@ -176,13 +176,14 @@ module.exports = function (Spotlight) {
         * @returns {Number} The precedence value.
         * @private
         */
-        _getPrecedenceValue = function(oPoints, sDirection) {
-            var delta = _getDelta(oPoints[0], oPoints[1]),
+        _getPrecedenceValue = function(oPoints, sDirection, oEvent) {
+            var pow = oEvent && oEvent.spotlightPrecedence || 4,
+				delta = _getDelta(oPoints[0], oPoints[1]),
                 slope = _getSlope(delta, sDirection),
                 angle = _getAngle(slope),
                 distance = _getDistance(delta);
 
-            return angle > 90 ? 0 : 1 / (angle * Math.pow(distance, 4));
+            return angle > 90 ? 0 : 1 / (angle * Math.pow(distance, pow));
         },
 
         /**
@@ -274,7 +275,7 @@ module.exports = function (Spotlight) {
         * @returns {Number}
         * @private
         */
-        _calculateNearestNeighbor = function(o, sDirection, oBounds1, oControl) {
+        _calculateNearestNeighbor = function(o, sDirection, oBounds1, oControl, oEvent) {
             var n,
                 oBounds2,
                 nPrecedence,
@@ -297,7 +298,7 @@ module.exports = function (Spotlight) {
                     // If control is in half plane specified by direction
                     if (_isInHalfPlane(sDirection, oBounds1, oBounds2)) {
                         // Find control with highest precedence to the direction
-                        nPrecedence = _getAdjacentControlPrecedence(sDirection, oBounds1, oBounds2);
+                        nPrecedence = _getAdjacentControlPrecedence(sDirection, oBounds1, oBounds2, oEvent);
                         if (nPrecedence > nBestMatch) {
                             nBestMatch = nPrecedence;
                             oBestMatch = oSibling;
@@ -346,7 +347,7 @@ module.exports = function (Spotlight) {
     * @returns {Object} The nearest neighbor of the pointer.
     * @public
     */
-    this.getNearestPointerNeighbor = function(oRoot, sDirection, nPositionX, nPositionY) {
+    this.getNearestPointerNeighbor = function(oRoot, sDirection, nPositionX, nPositionY, oEvent) {
         var oBounds = {
                 left: nPositionX,
                 top: nPositionY,
@@ -355,7 +356,7 @@ module.exports = function (Spotlight) {
             },
             o = Spotlight.getChildren(oRoot, true);
 
-        return _calculateNearestNeighbor(o, sDirection, oBounds);
+        return _calculateNearestNeighbor(o, sDirection, oBounds, null, oEvent);
     };
 
     /**
@@ -367,7 +368,7 @@ module.exports = function (Spotlight) {
     * @returns {Object} The nearest neighbor of the control.
     * @public
     */
-    this.getNearestNeighbor = function(sDirection, oControl, oOpts) {
+    this.getNearestNeighbor = function(sDirection, oControl, oOpts, oEvent) {
         var oRoot = oOpts && oOpts.root,
             oNeighbor,
             oCandidates,
@@ -405,6 +406,6 @@ module.exports = function (Spotlight) {
 
         oBounds = oControl.getAbsoluteBounds();
 
-        return _calculateNearestNeighbor(oCandidates, sDirection, oBounds, oControl);
+        return _calculateNearestNeighbor(oCandidates, sDirection, oBounds, oControl, oEvent);
     };
 };

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -462,7 +462,7 @@ var Spotlight = module.exports = new function () {
         _5WayMove = function(oEvent) {
             var sDirection = oEvent.type.replace('onSpotlight', '').toUpperCase(),
                 leave = oEvent.requestLeaveContainer,
-                oControl = !leave && _oThis.NearestNeighbor.getNearestNeighbor(sDirection);
+                oControl = !leave && _oThis.NearestNeighbor.getNearestNeighbor(sDirection, null, null, oEvent);
 
 
             // If oEvent.allowDomDefault() was not called
@@ -709,7 +709,8 @@ var Spotlight = module.exports = new function () {
                     getNearestPointerNeighbor(_oRoot,
                         sDir,
                         _nPrevClientX,
-                        _nPrevClientY
+                        _nPrevClientY,
+						oEvent
                     );
             if (oNearest) {
                 _oThis.spot(oNearest, {direction: sDir});


### PR DESCRIPTION
Issue:
Spotlight is having fixed calculation weight factor on
_getPrecedenceValue. But, there is some cases that angle is more
important than distance like this issue.

Fix:
We add an option to setup the weight. So, developer can set option on
each control.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>