### PR TITLE
ENYO-2657: Always calculate neighbor from last non-container

### DIFF
--- a/src/neighbor.js
+++ b/src/neighbor.js
@@ -371,6 +371,7 @@ module.exports = function (Spotlight) {
         var oRoot = oOpts && oOpts.root,
             oNeighbor,
             oCandidates,
+            oNonContainer,
             oBounds;
 
         sDirection = sDirection.toUpperCase();
@@ -399,9 +400,11 @@ module.exports = function (Spotlight) {
 
         // If the control is container, the nearest neighbor is calculated based on the bounds
         // of last focused child of container.
-        if (Spotlight.isContainer(oControl)) {
-            oControl = Spotlight.Container.getLastFocusedChild(oControl) || oControl;
+        oNonContainer = oControl;
+        while (Spotlight.isContainer(oNonContainer)) {
+            oNonContainer = Spotlight.Container.getLastFocusedChild(oNonContainer);
         }
+        oControl = oNonContainer || oControl;
 
         oBounds = oControl.getAbsoluteBounds();
 


### PR DESCRIPTION
We have long had logic in Spotlight to use a container's last
focused child when performing a nearest-neighbor calculation from
the container. However, that logic didn't account for the case
where there were nested containers. We adjust it so that it now
does.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)