### PR TITLE
ENYO-2519: Accessibility: The focus disappears from the screen when I…

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1241,13 +1241,8 @@ var Spotlight = module.exports = new function () {
         // Accessibility - Set focus to read aria label.
         // Do not focus labels (e.g. moonstone/InputDecorator) since the default behavior is to
         // transfer focus to its internal input.
-        if (options.accessibility && !this.getPointerMode()) {
-            if (c && !c.accessibilityDisabled && c.tag != 'label') {
-                c.focus();
-            }
-            else if (document.activeElement) {
-                document.activeElement.blur();
-            }
+        if (options.accessibility && !this.getPointerMode() && c && !c.accessibilityDisabled && c.tag != 'label') {
+            c.focus();
         }
     };
 
@@ -1258,7 +1253,11 @@ var Spotlight = module.exports = new function () {
     * @param {Object} oEvent - The current event.
     * @public
     */
-    this.onSpotlightBlur = function(oEvent) {};
+    this.onSpotlightBlur = function(oEvent) {
+        if (oEvent.originator) {
+            oEvent.originator.blur();
+        }
+    };
 
     /**
     * Initializes Spotlight's flags and root.


### PR DESCRIPTION
… expand the ExpandableInput using 4way key.

Issue
The focus disappears from the screen and the virtual keyboard doesn't appear.
The focus does not come back again using 4way key.

Cause
When ExpandablePicker is selected, InputDecorator is blured after it focused.

Fix
Call the blur api in onSpotlightBlur to prevent blur after focusing

https://jira2.lgsvl.com/browse/ENYO-2519
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>