### PR TITLE
Fixes ENYO-2519

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1245,8 +1245,8 @@ var Spotlight = module.exports = new function () {
             if (c && !c.accessibilityDisabled && c.tag != 'label') {
                 c.focus();
             }
-            else if (document.activeElement) {
-                document.activeElement.blur();
+            else if (oEvent.previous) {
+                oEvent.previous.blur();
             }
         }
     };


### PR DESCRIPTION
Blurring the activeElement could inadvertently blur an unspottable
control (like the moonstone/Input within a moonstone/InputDecorator).
Instead, only blur the previously spotted control which would have been
focused by spotlight before.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)