### PR TITLE
ENYO-2524: Factor "default direction" logic out of nearest neighbor

### DIFF
--- a/src/neighbor.js
+++ b/src/neighbor.js
@@ -369,27 +369,11 @@ module.exports = function (Spotlight) {
     */
     this.getNearestNeighbor = function(sDirection, oControl, oOpts) {
         var oRoot = oOpts && oOpts.root,
-            oNeighbor,
             oCandidates,
             oBounds;
 
         sDirection = sDirection.toUpperCase();
         oControl = oControl || Spotlight.getCurrent();
-
-        // Check to see if default direction is specified
-        oNeighbor = Spotlight.Util.getDefaultDirectionControl(sDirection, oControl);
-		if (oNeighbor) {
-			if (Spotlight.isSpottable(oNeighbor)) {
-				return oNeighbor;
-			} else {
-				oNeighbor = Spotlight.getFirstChild(oNeighbor);
-				if (oNeighbor && Spotlight.isSpottable(oNeighbor)) { 
-					return oNeighbor;
-				}
-			}
-		}
-
-        // If default control in the direction of navigation is not specified, calculate it
 
         // If we've been passed a root, find the best match among its children;
         // otherwise, find the best match among siblings of the reference control


### PR DESCRIPTION
Spotlight has a feature allowing a "default" target to be set for
a 5-way move in a specific direction from a specific origin. When
a default target is set, it short-circuits the nearest neighbor
calculation that would normally happen.

From an implementation point of view, the logic for identifying and
returning the default target has historically resided inside the
`getNearestNeighbor()` method, but with the recent addition of the
`spotlightRememberFocus` option for containers, this coupling can
now cause an infinite-recursion issue in certain cases.

To avoid such cases, we will factor the default-target-acquisition
logic out of `getNearestNeighbor()` so that it can be applied in
the cases where it is needed and skipped in the cases where it is
problematic. This factoring seems conceptually purer as well, since
`getNearestNeighbor()` is now only responsible for...well, getting
the nearest neighbor.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)