### PR TITLE
ENYO-2548: Do mute on window blur and webOSMouse leave

### DIFF
--- a/src/muter.js
+++ b/src/muter.js
@@ -16,13 +16,12 @@ module.exports = function (Spotlight) {
     /**
     * Mutes a control.
     *
-    * @param  {Object} oSender - The control to be muted.
+    * @param  {Object|String} oSender - The control or id to be muted.
     * @public
     */
     this.addMuteReason = function(oSender) {
-        if (typeof _oMutes[oSender.id] != 'undefined') {
-            return;
-        }
+		var id = typeof oSender == 'string' ? oSender : oSender.id;
+		if (_oMutes[id]) return;
 
         if (_nMutes === 0) {
             var oCurrent = Spotlight.getCurrent();
@@ -31,22 +30,21 @@ module.exports = function (Spotlight) {
             }
         }
 
-        _oMutes[oSender.id] = 1;
+        _oMutes[id] = true;
         _nMutes++;
     };
 
     /**
     * Un-mutes a muted control.
     *
-    * @param  {Object} oSender - The control to be un-muted.
+    * @param  {Object|String} oSender - The control or id to be un-muted.
     * @public
     */
     this.removeMuteReason = function(oSender) {
-        if (typeof _oMutes[oSender.id] == 'undefined') {
-            return;
-        }
+		var id = typeof oSender == 'string' ? oSender : oSender.id;
+		if (!_oMutes[id]) return;
 
-        delete _oMutes[oSender.id];
+        _oMutes[id] = null;
         _nMutes--;
 
         if (_nMutes === 0) {

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -789,8 +789,8 @@ var Spotlight = module.exports = new function () {
 						if (oEvent.detail.type == 'Leave') {
 							this.setPointerMode(false);
 							this.unspot();
-							this.mute();
 							this.setPointerMode(true);
+							this.mute();
 						}
 						if (oEvent.detail.type == 'Enter') {
 							this.unmute();
@@ -799,13 +799,13 @@ var Spotlight = module.exports = new function () {
                     break;
                 case 'focus':
                     if (oEvent.target === window) {
+						this.unmute();
                         // Update pointer mode from cursor visibility platform API
                         if (window.PalmSystem && window.PalmSystem.cursor) {
                             this.setPointerMode( window.PalmSystem.cursor.visibility );
                         }
                         // Whenever app goes to foreground, refocus on last focused control
                         _spotLastControl();
-						this.unmute();
                     }
                     break;
                 case 'blur':

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -790,16 +790,16 @@ var Spotlight = module.exports = new function () {
                             this.setPointerMode(false);
                             this.unspot();
                             this.setPointerMode(true);
-                            this.mute();
+                            this.mute({id: 'window.focus'});
                         }
                         if (oEvent.detail.type == 'Enter') {
-                            this.unmute();
+                            this.unmute({id: 'window.focus'});
                         }
                     }
                     break;
                 case 'focus':
                     if (oEvent.target === window) {
-                        this.unmute();
+                        this.unmute({id: 'window.focus'});
                         // Update pointer mode from cursor visibility platform API
                         if (window.PalmSystem && window.PalmSystem.cursor) {
                             this.setPointerMode( window.PalmSystem.cursor.visibility );
@@ -813,7 +813,7 @@ var Spotlight = module.exports = new function () {
                         // Whenever app goes to background, unspot focus
                         this.unspot();
                         this.setPointerMode(false);
-                        this.mute();
+                        this.mute({id: 'window.focus'});
                     }
                     break;
                 case 'move':

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -784,22 +784,22 @@ var Spotlight = module.exports = new function () {
         if (this.isInitialized()) {
             switch (oEvent.type) {
                 case 'webOSMouse':
-					// webOSMouse event comes only when pointer mode
+                    // webOSMouse event comes only when pointer mode
                     if (oEvent && oEvent.detail) {
-						if (oEvent.detail.type == 'Leave') {
-							this.setPointerMode(false);
-							this.unspot();
-							this.setPointerMode(true);
-							this.mute();
-						}
-						if (oEvent.detail.type == 'Enter') {
-							this.unmute();
-						}
+                        if (oEvent.detail.type == 'Leave') {
+                            this.setPointerMode(false);
+                            this.unspot();
+                            this.setPointerMode(true);
+                            this.mute();
+                        }
+                        if (oEvent.detail.type == 'Enter') {
+                            this.unmute();
+                        }
                     }
                     break;
                 case 'focus':
                     if (oEvent.target === window) {
-						this.unmute();
+                        this.unmute();
                         // Update pointer mode from cursor visibility platform API
                         if (window.PalmSystem && window.PalmSystem.cursor) {
                             this.setPointerMode( window.PalmSystem.cursor.visibility );
@@ -813,7 +813,7 @@ var Spotlight = module.exports = new function () {
                         // Whenever app goes to background, unspot focus
                         this.unspot();
                         this.setPointerMode(false);
-						this.mute();
+                        this.mute();
                     }
                     break;
                 case 'move':

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -784,11 +784,17 @@ var Spotlight = module.exports = new function () {
         if (this.isInitialized()) {
             switch (oEvent.type) {
                 case 'webOSMouse':
-                    if (oEvent && oEvent.detail && oEvent.detail.type == 'Leave') {
-                        // webOSMouse event comes only when pointer mode
-                        this.setPointerMode(false);
-                        this.unspot();
-                        this.setPointerMode(true);
+					// webOSMouse event comes only when pointer mode
+                    if (oEvent && oEvent.detail) {
+						if (oEvent.detail.type == 'Leave') {
+							this.setPointerMode(false);
+							this.unspot();
+							this.mute();
+							this.setPointerMode(true);
+						}
+						if (oEvent.detail.type == 'Enter') {
+							this.unmute();
+						}
                     }
                     break;
                 case 'focus':
@@ -799,6 +805,7 @@ var Spotlight = module.exports = new function () {
                         }
                         // Whenever app goes to foreground, refocus on last focused control
                         _spotLastControl();
+						this.unmute();
                     }
                     break;
                 case 'blur':
@@ -806,6 +813,7 @@ var Spotlight = module.exports = new function () {
                         // Whenever app goes to background, unspot focus
                         this.unspot();
                         this.setPointerMode(false);
+						this.mute();
                     }
                     break;
                 case 'move':

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -790,16 +790,16 @@ var Spotlight = module.exports = new function () {
                             this.setPointerMode(false);
                             this.unspot();
                             this.setPointerMode(true);
-                            this.mute({id: 'window.focus'});
+                            this.mute('window.focus');
                         }
                         if (oEvent.detail.type == 'Enter') {
-                            this.unmute({id: 'window.focus'});
+                            this.unmute('window.focus');
                         }
                     }
                     break;
                 case 'focus':
                     if (oEvent.target === window) {
-                        this.unmute({id: 'window.focus'});
+                        this.unmute('window.focus');
                         // Update pointer mode from cursor visibility platform API
                         if (window.PalmSystem && window.PalmSystem.cursor) {
                             this.setPointerMode( window.PalmSystem.cursor.visibility );
@@ -813,7 +813,7 @@ var Spotlight = module.exports = new function () {
                         // Whenever app goes to background, unspot focus
                         this.unspot();
                         this.setPointerMode(false);
-                        this.mute({id: 'window.focus'});
+                        this.mute('window.focus');
                     }
                     break;
                 case 'move':


### PR DESCRIPTION
Issue:
- When floating app is request window focus, background app doesn't get
  mouse events.
- But, when background app is actively move focus to other, dual focus
  can be happens.
- This can be happens by plug out drive while playing music on player.

Fix:
- We mute spotlight on window blur. So, any kind of focus move on
  background app can be done safely without highlighting focus.
- Unmute when window get focus back. So, last focused item can be highlighted.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>