### PR TITLE
ENYO-2629: Set pointer mode true before unspot on webOSMouse leave

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -785,8 +785,6 @@ var Spotlight = module.exports = new function () {
             switch (oEvent.type) {
                 case 'webOSMouse':
                     if (oEvent && oEvent.detail && oEvent.detail.type == 'Leave') {
-                        // webOSMouse event comes only when pointer mode
-                        this.setPointerMode(true);
                         this.unspot();
                     }
                     break;

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -786,9 +786,8 @@ var Spotlight = module.exports = new function () {
                 case 'webOSMouse':
                     if (oEvent && oEvent.detail && oEvent.detail.type == 'Leave') {
                         // webOSMouse event comes only when pointer mode
-                        this.setPointerMode(false);
-                        this.unspot();
                         this.setPointerMode(true);
+                        this.unspot();
                     }
                     break;
                 case 'focus':


### PR DESCRIPTION
Issue:
Music player has close button and hide it on blue. When user move mouse
pointer from close button to outside of player, sing icon is getting
focus back even on pointer mode. This is because webOSMouse event comes
on mouse leave, and spotlight handler is set pointer mode false before
calling unspot. Close button is hide itself while it is focused by blur
handler.

Fix:
We don't need to change pointer mode as false before calling unspot to
solve previous dual focus issue. So, we set pointer mode true prior to
unspot. It will block spot call on disappear routine.

Enyo-1.1-DCO-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>