### PR TITLE
ENYO-2744: Allow setting lastFocusedChild to null

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -242,10 +242,15 @@ module.exports = function (Spotlight) {
     * Sets last focused child for the container.
     *
     * @param  {Object} oSender
-    * @param  {Object} oChild - The child to set as the last focused child.
+    * @param  {Object} oChild - The child to set as the last focused child. Set to `null`
+    *   to clear the last focused child.
     * @public
     */
     this.setLastFocusedChild = function(oSender, oChild) {
+        if (oChild === null) {
+            oSender._spotlight.lastFocusedChild = null;
+            return;
+        }
         if (!Spotlight.isSpottable(oChild)) {
             oChild = Spotlight.getFirstChild(oChild);
         }


### PR DESCRIPTION
We have long had, for special cases, a public API allowing the
last focused child of a Spotlight container to be explicitly set.

We have a new use case where we want to set it to `null`, so
extending the API accordingly.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)