### PR TITLE
Fixes ENYO-2770

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -341,7 +341,7 @@ var Spotlight = module.exports = new function () {
             if (!oControl || !_oThis.isSpottable(oControl)) {
 
                 // Find first spottable parent
-                oControl = _oThis.getParent();
+                oControl = _oThis.getParent() || _oThis.getFirstChild(_oRoot);
                 if (!oControl) {
                     _unhighlight(_oLastControl);
                     _oLastControl = null;


### PR DESCRIPTION
Issue
When a control is destroyed, Spotlight is unable to get its parent
because it has already been nulled by the time the destroyed observers
are invoked.

Fix
add back the call to retrieve the first spottable control as a fallback

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)