### PR TITLE
Partial fix for ENYO-2796

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -276,7 +276,7 @@ module.exports = function (Spotlight) {
                     continue;
                 }
                 position = dom.compareDocumentPosition(to, from.hasNode());
-                if(position & 8) {  // 8 == 'contains'
+                if(from == focusedControl || (position & 8)) {  // 8 == 'contains'
                     Spotlight.Util.dispatchEvent('onSpotlightContainerLeave', {
                         commonAncestor: from
                     }, blurredControl);


### PR DESCRIPTION
We need to ensure that containers that are ancestors of the previous spotted control are not receiving the onSpotlightContainerLeave event when it isn't actually being exited.


Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)