### PR TITLE
ENYO-2485: Accessibility: When cardArranger panels are switched, scre…

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1318,7 +1318,9 @@ var Spotlight = module.exports = new function () {
         // transfer focus to its internal input.
         if (options.accessibility && !this.getPointerMode()) {
             if (c && !c.accessibilityDisabled && c.tag != 'label') {
-                c.focus();
+                setTimeout(function () {
+                    c.focus();
+                }, 50);
             }
             else if (oEvent.previous) {
                 oEvent.previous.blur();


### PR DESCRIPTION
…en reader doesn't read the focused item.

Add time delay for dom focus to read panel title(alert) earlier than focused item.

https://jira2.lgsvl.com/browse/ENYO-2485
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>