### PR TITLE
ENYO-2880: End any holds when blurring.

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -495,7 +495,7 @@ var Spotlight = module.exports = new function () {
                     return oTarget;
                 } else {
                     oTarget = _oThis.getFirstChild(oTarget);
-                    if (oTarget && _oThis.isSpottable(oTarget)) { 
+                    if (oTarget && _oThis.isSpottable(oTarget)) {
                         return oTarget;
                     }
                 }
@@ -843,6 +843,10 @@ var Spotlight = module.exports = new function () {
                         // Whenever app goes to background, unspot focus
                         this.unspot();
                         this.setPointerMode(false);
+
+                        // Stop any hold/holdpulses that may currently be active
+                        gesture.drag.endHold();
+
                         this.mute('window.focus');
                     }
                     break;


### PR DESCRIPTION
### Issue
When the current application is blurred and a `hold`/`holdpulse` is currently active, this event continues in the newly active application.

### Fix
We always end any holds when blurring the application, similar to our calls to `unspot` and `setPointerMode(false)`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>