### PR TITLE
ENYO-2784: When the LightPanels are switched, screen reader doesn't read the focused item.

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1331,11 +1331,7 @@ var Spotlight = module.exports = new function () {
         // transfer focus to its internal input.
         if (options.accessibility && !this.getPointerMode()) {
             if (c && !c.accessibilityDisabled && c.tag != 'label') {
-                setTimeout(function () {
-                    if (Spotlight.getCurrent() === c) {
-                        c.focus();
-                    }
-                }, 50);
+                c.focus();
             }
             else if (oEvent.previous) {
                 oEvent.previous.blur();

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1323,8 +1323,7 @@ var Spotlight = module.exports = new function () {
     * @public
     */
     this.onSpotlightFocused = function(oEvent) {
-        var c = oEvent.originator,
-            Spotlight = this;
+        var c = oEvent.originator;
 
         // Accessibility - Set focus to read aria label.
         // Do not focus labels (e.g. moonstone/InputDecorator) since the default behavior is to


### PR DESCRIPTION
Fix for ENYO-2784 and ENYO-2485

https://jira2.lgsvl.com/browse/ENYO-2784?filter=-1
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang jaewon98.jang@lgepartner.com