### PR TITLE
PLAT-15245: Edit guard code to enable touch event support in Enyo and…

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1396,7 +1396,7 @@ var Spotlight = module.exports = new function () {
     * @public
     */
     this.setPointerMode = function(bPointerMode) {
-        if ((_bPointerMode != bPointerMode) && (!platform.touch)) {
+        if (_bPointerMode != bPointerMode) {
             _bPointerMode = bPointerMode;
             _log('Pointer mode', _bPointerMode);
             _nMouseMoveCount = 0;

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -4,7 +4,6 @@ var
     logger = require('enyo/logger'),
     master = require('enyo/master'),
     options = require('enyo/options'),
-    platform = require('enyo/platform'),
     roots = require('enyo/roots'),
     utils = require('enyo/utils'),
     Component = require('enyo/Component'),


### PR DESCRIPTION
… Moonstone for WebOS3.0-based Signage.

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>


Should note, tested with bluetooth keyboard on android device with success. Gives benefit of working 5way on modern touch devices (touch-enabled PCs, tablets with keyboards, phones with keyboards, etc.). Appears to be no apparently bugs/side effects based off testing with Enyo Strawman app.