### PR TITLE
ENYO-1608: Thoroughly discovers the spottable target for a given node.

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -495,7 +495,7 @@ var Spotlight = module.exports = new function () {
                     return oTarget;
                 } else {
                     oTarget = _oThis.getFirstChild(oTarget);
-                    if (oTarget && _oThis.isSpottable(oTarget)) { 
+                    if (oTarget && _oThis.isSpottable(oTarget)) {
                         return oTarget;
                     }
                 }
@@ -625,15 +625,21 @@ var Spotlight = module.exports = new function () {
         },
 
         /**
-        * Gets spottable target by id for pointer events.
+        * Gets spottable target for pointer events.
         *
-        * @param {String} sId - String ID of target.
+        * @param {Object} oDomTarget - The target node to start from.
         * @return {Object} - The spottable target.
         * @private
         */
-        _getTarget = function(sId) {
-            var oTarget = dispatcher.$[sId];
-            if (typeof oTarget != 'undefined') {
+        _getSpottableTarget = function(oDomTarget) {
+            var oTarget;
+
+            do {
+                oTarget = oDomTarget && dispatcher.$[oDomTarget.id];
+                oDomTarget = oDomTarget && oDomTarget.parentNode;
+            } while (!oTarget && oDomTarget);
+
+            if (oTarget) {
                 if (_oThis.isSpottable(oTarget)) {
                     return oTarget;
                 } else {
@@ -1014,7 +1020,7 @@ var Spotlight = module.exports = new function () {
         // Preserving explicit setting of mode for future features
         this.setPointerMode(true);
         if (this.getPointerMode()) {
-            var oTarget = _getTarget(oEvent.target.id);
+            var oTarget = _getSpottableTarget(oEvent.target);
             if (oTarget && !this.isContainer(oTarget)) {
 
                 if (
@@ -1045,7 +1051,7 @@ var Spotlight = module.exports = new function () {
         // Logic to exit frozen mode when depressing control other than current
         // And transfer spotlight directly to it
         if (this.isFrozen()) {
-            var oTarget = _getTarget(oEvent.target.id);
+            var oTarget = _getSpottableTarget(oEvent.target);
             if (oTarget != _oCurrent && !oEvent.defaultPrevented) {
                 this.unfreeze();
                 this.unspot();
@@ -1804,7 +1810,7 @@ var Spotlight = module.exports = new function () {
     *
     * @public
     */
-    this.unfreeze = function() { 
+    this.unfreeze = function() {
         _bFrozen = false;
     };
 


### PR DESCRIPTION
### Issue
When there are standard HTML elements nested in Enyo controls, spotting with the pointer does not work correctly as the first spottable parent would not be found.

### Fix
Inspired by the fix from https://github.com/enyojs/spotlight/pull/205, we have consolidated this logic into `_getSpottableTarget` (the artist formerly known as `_getTarget`) as the operations were very related, and semantically we are trying to find a _spottable_ target, and not a target based on an id.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>