### PR TITLE
ENYO-2912: Unmute('window.focus') on key down and pointer hide

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -495,7 +495,7 @@ var Spotlight = module.exports = new function () {
                     return oTarget;
                 } else {
                     oTarget = _oThis.getFirstChild(oTarget);
-                    if (oTarget && _oThis.isSpottable(oTarget)) { 
+                    if (oTarget && _oThis.isSpottable(oTarget)) {
                         return oTarget;
                     }
                 }
@@ -1139,6 +1139,9 @@ var Spotlight = module.exports = new function () {
 
                 // Pointer hidden event; set pointer mode false
             case KEY_POINTER_HIDE:
+
+                this.unmute('window.focus');
+
                 setTimeout(function() {
                     if (this.getPointerMode()) {
                         this.setPointerMode(false);
@@ -1160,6 +1163,8 @@ var Spotlight = module.exports = new function () {
         if (_is5WayKey(oEvent)) {
             var bWasPointerMode = this.getPointerMode();
             this.setPointerMode(false);
+
+            this.unmute('window.focus');
 
             // Spot first available control on bootstrap
             if (!this.isSpottable(this.getCurrent()) ||
@@ -1804,7 +1809,7 @@ var Spotlight = module.exports = new function () {
     *
     * @public
     */
-    this.unfreeze = function() { 
+    this.unfreeze = function() {
         _bFrozen = false;
     };
 


### PR DESCRIPTION
### Issue:
We mute('window.focus') spotlight on webOSLeave event to prevent unwanted focus highlight on active app change like plug out USB media while showing other floating type app. A floating type window of webOs is not get key event while hover and it is actually not active app before the app is specifically request key focus.  Therefore, active app (at the back) is getting the key event while hover over floating app. But, no webOSEnter event comes to active app. As a result, ghost focus problem happens when user press 5way key while hover pointer over floating app. User can see tooltip but there is no focus highlighted on active app because it is still muted.

### Fix:
We unmute('window.focus') on 5 way key event and pointer hide event comes. so, it can safely release mute state when user want to change focus intentionally.
This is only unmute reason from framework and any other mute reason comes from app will not be affected.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi kunmyon.choi@lge.com