### PR TITLE
ENYO-3091: Support spotlightRememberFocus option on getLastFocusedChild

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -247,7 +247,7 @@ module.exports = function (Spotlight) {
     * @public
     */
     this.setLastFocusedChild = function(oSender, oChild) {
-        if (oChild === null) {
+        if (oSender.spotlightRememberFocus === false || oChild === null) {
             oSender._spotlight.lastFocusedChild = null;
             return;
         }


### PR DESCRIPTION
Issue:
We have spotlightRememberFocus option on spotlight container, but this only work on 5way key press case. So, if we want to apply this option on popup then it is not work in expected way. Meaning, remember last focus on show.

Fix:
Add a condition on getLastFocusedChild to pick first control when spotlightRememberFocus is false.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi kunmyon.choi@lge.com