### PR TITLE
ENYO-3093: Clean up gesture downEvent on window.blur

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -871,6 +871,11 @@ var Spotlight = module.exports = new function () {
 
                         // Stop any hold/holdpulses that may currently be active
                         gesture.drag.endHold();
+                        // the "downEvent" property is a private implementation detail of gesture,
+                        // but making the fix here as it is by far the simplest and least impactful
+                        if (gesture.downEvent) {
+                            gesture.up(gesture.downEvent);
+                        }
 
                         this.mute('window.focus');
                     }


### PR DESCRIPTION
Issue:
If switch app while drag, down event is not cleaned up. This make
app in dragging status after switch back to previously focused app.

Fix:
Explicitly call gesture.up when gesture.downEvent is not null on
window.blur event comes.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)