### PR TITLE
[ENYO-3260] Guarantee whole text reading before button focused

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1341,7 +1341,7 @@ var Spotlight = module.exports = new function () {
     */
     this.onSpotlightFocus = function(oEvent) {
         var c = oEvent.originator;
-        c.focusType = oEvent.focusType
+        c.focusType = oEvent.focusType;
         _setCurrent(c);
     };
 
@@ -1360,17 +1360,19 @@ var Spotlight = module.exports = new function () {
         // transfer focus to its internal input.
         if (options.accessibility && !this.getPointerMode()) {
             if (c && !c.accessibilityDisabled && c.tag != 'label') {
-                if(c.focusType == 'explicit' || c.focusType == 'default'){
+                if (c.focusType == 'explicit' || c.focusType == 'default') {
                     var aLabel = this.getAccessibilityCustomLabel(c);
-                    if(aLabel && aLabel.length>0){
+                    if (c._accessibilityLabel == undefined && aLabel && aLabel.length>0) {
                         var aOrgLabel = c.get("accessibilityLabel");
-                        var aNewLabel = aLabel + ( aOrgLabel || c.get("content") );
+                        var aNewLabel = aLabel + ( aOrgLabel || c.get("caption") || c.get("content") );
 
-                        c.accessibilityCustomLabel = aOrgLabel;
+                        c._accessibilityLabel = aOrgLabel;
+
                         c.set("accessibilityLabel", aNewLabel);
 
                         setTimeout(function(cTarget) {
-                            cTarget.set("accessibilityLabel", cTarget.accessibilityCustomLabel);
+                            cTarget.set("accessibilityLabel", cTarget._accessibilityLabel);
+                            cTarget._accessibilityLabel =  undefined;
                         }.bind(this), 100, c);
                     }
                 }
@@ -1397,13 +1399,13 @@ var Spotlight = module.exports = new function () {
         var aCustomLabel = '';
         do {
             if (oControl.accessibilityCustomLabel) {
-                if(oControl.owner && typeof oControl.owner[oControl.accessibilityCustomLabel] == 'function'){
+                if(typeof oControl.accessibilityCustomLabel == 'function' && oControl.owner && oControl.owner[oControl.accessibilityCustomLabel]) {
                     aCustomLabel = oControl.owner[oControl.accessibilityCustomLabel](oControl) + aCustomLabel;
                 } else {
                     aCustomLabel = oControl.accessibilityCustomLabel + aCustomLabel;
                 }
             }
-            if (oControl.accessibilityCustomLabelBound){
+            if (oControl.accessibilityCustomLabelBound) {
                 break;
             }
             oControl = oControl.parent;

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1340,7 +1340,9 @@ var Spotlight = module.exports = new function () {
     * @public
     */
     this.onSpotlightFocus = function(oEvent) {
-        _setCurrent(oEvent.originator);
+        var c = oEvent.originator;
+        c.focusType = oEvent.focusType
+        _setCurrent(c);
     };
 
     /**
@@ -1358,12 +1360,55 @@ var Spotlight = module.exports = new function () {
         // transfer focus to its internal input.
         if (options.accessibility && !this.getPointerMode()) {
             if (c && !c.accessibilityDisabled && c.tag != 'label') {
+                if(c.focusType == 'explicit' || c.focusType == 'default'){
+                    var aLabel = this.getAccessibilityCustomLabel(c);
+                    if(aLabel && aLabel.length>0){
+                        var aOrgLabel = c.get("accessibilityLabel");
+                        var aNewLabel = aLabel + ( aOrgLabel || c.get("content") );
+
+                        c.accessibilityCustomLabel = aOrgLabel;
+                        c.set("accessibilityLabel", aNewLabel);
+
+                        setTimeout(function(cTarget) {
+                            cTarget.set("accessibilityLabel", cTarget.accessibilityCustomLabel);
+                        }.bind(this), 100, c);
+                    }
+                }
                 c.focus();
             }
             else if (oEvent.previous) {
                 oEvent.previous.blur();
             }
         }
+    };
+
+    /**
+    * Search parent and add accessibilityCustomLabel text when reach accessibilityCustomLabelBound property
+    *
+    * @method
+    * @param {oControl} oControl - The focused control.
+    * @public
+    */
+    this.getAccessibilityCustomLabel = function(oControl) {
+        oControl = oControl || this.getCurrent();
+        if (!oControl) {
+            return;
+        }
+        var aCustomLabel = '';
+        do {
+            if (oControl.accessibilityCustomLabel) {
+                if(oControl.owner && typeof oControl.owner[oControl.accessibilityCustomLabel] == 'function'){
+                    aCustomLabel = oControl.owner[oControl.accessibilityCustomLabel](oControl) + aCustomLabel;
+                } else {
+                    aCustomLabel = oControl.accessibilityCustomLabel + aCustomLabel;
+                }
+            }
+            if (oControl.accessibilityCustomLabelBound){
+                break;
+            }
+            oControl = oControl.parent;
+        } while (oControl);
+        return aCustomLabel;
     };
 
     /**

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1362,7 +1362,7 @@ var Spotlight = module.exports = new function () {
             if (c && !c.accessibilityDisabled && c.tag != 'label') {
                 if (c.focusType == 'explicit' || c.focusType == 'default') {
                     var aLabel = this.getAccessibilityCustomLabel(c);
-                    if (c._accessibilityLabel == undefined && aLabel && aLabel.length>0) {
+                    if (c._accessibilityLabel === undefined && aLabel && aLabel.length>0) {
                         var aOrgLabel = c.get("accessibilityLabel");
                         var aNewLabel = aLabel + ( aOrgLabel || c.get("caption") || c.get("content") );
 
@@ -1372,7 +1372,7 @@ var Spotlight = module.exports = new function () {
 
                         setTimeout(function(cTarget) {
                             cTarget.set("accessibilityLabel", cTarget._accessibilityLabel);
-                            cTarget._accessibilityLabel =  undefined;
+                            cTarget._accessibilityLabel = undefined;
                         }.bind(this), 100, c);
                     }
                 }


### PR DESCRIPTION
Guarantee whole text reading before button focused in audio guidance

Enyo-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>