### PR TITLE
ENYO-3319 : Delegate focusType property to onSpotFocused handler

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -434,7 +434,7 @@ var Spotlight = module.exports = new function () {
         * @param {Object} oControl - The control to be spotted.
         * @private
         */
-        _setCurrent = function(oControl) {
+        _setCurrent = function(oControl, oEvent) {
             _initializeControl(oControl);
 
             if (!_oThis.isSpottable(oControl)) {
@@ -471,7 +471,8 @@ var Spotlight = module.exports = new function () {
                 _oLastControl = oControl;
             }
 
-            _dispatchEvent('onSpotlightFocused', {previous: oPrevious});
+            oEvent = oEvent ? (oEvent.previous = oPrevious, oEvent) : {previous: oPrevious};
+            _dispatchEvent('onSpotlightFocused', oEvent);
 
             _oThis.TestMode.highlight();
 
@@ -1340,7 +1341,7 @@ var Spotlight = module.exports = new function () {
     * @public
     */
     this.onSpotlightFocus = function(oEvent) {
-        _setCurrent(oEvent.originator);
+        _setCurrent(oEvent.originator, oEvent);
     };
 
     /**


### PR DESCRIPTION
In current state, focusType info delegate until OnSpotlightFocus handler.
If this info delegate to OnSpotlightFocused handler,
App developer can determine whether current focus is initial('explict' or 'default )' or not('5-way'),

Enyo-DCO-1.1-Signed-off-by: Changgi Lee changgi.lee@lge.com
