### PR TITLE
ENYO-3368: Focus jump to first item on spotlight container if previous

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -188,7 +188,8 @@ module.exports = function (Spotlight) {
             // Default container behavior is to refocus the last-focused child, but
             // some containers may prefer to focus the child nearest the originator
             // of the 5-way event
-            if (o5WayEvent && oSender.spotlightRememberFocus === false) {
+            if (o5WayEvent && oSender.spotlightRememberFocus === false && 
+                o5WayEventOriginator && o5WayEventOriginator.getAbsoluteShowing()) {
                 oChildToFocus = Spotlight.NearestNeighbor.getNearestNeighbor(
                     // 5-way direction
                     s5WayEventDir,


### PR DESCRIPTION
scene closed by 4way right and back key

### Issue:
Spotlight container focused handler find nearest neighbor when
spotlightRememberFocus false. It use last5WayEvent to find
nearest neighbor control. The last5WayEvent is reset to null when
onSpotlightSelect event comes. When scene change is triggered by
non 5way event (back key), last5WayEvent is remains after scene
change. This makes container find nearest neighbor which is invalid.

### Fix:
When we find nearest neighbor, it assume the last 5way control is
visible and control bounds is valid. In problem case, the last 5way
control is not visible and control bounds is not valid. So, we can
filter out the invalid case by checking absolute showing status.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)