### PR TITLE
ENYO-3381 : Button is not read when window restore focus

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1726,6 +1726,9 @@ var Spotlight = module.exports = new function () {
             _oLastMouseMoveTarget = null;
             _dispatchEvent('onSpotlightBlur', {next: oNext}, _oCurrent);
             _observeDisappearance(false, _oCurrent);
+            if(_oCurrent.hasNode()){
+                _oCurrent.node.blur();
+            }
             _oCurrent = null;
             return true;
         }

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1726,7 +1726,7 @@ var Spotlight = module.exports = new function () {
             _oLastMouseMoveTarget = null;
             _dispatchEvent('onSpotlightBlur', {next: oNext}, _oCurrent);
             _observeDisappearance(false, _oCurrent);
-            if(_oCurrent.hasNode()){
+            if (_oCurrent.hasNode()) {
                 _oCurrent.node.blur();
             }
             _oCurrent = null;


### PR DESCRIPTION
Issue
:Button's audio guidance is not fire when window restore focus

Fix
:Apply dom node blur in unspot func

Enyo-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>