### PR TITLE
ENYO-3421: Spotlight focus jump or lost when show/hide popup repeatedly

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1763,10 +1763,8 @@ var Spotlight = module.exports = new function () {
             _nPrevClientY !== oEvent.clientY
         );
 
-        if (this.getPointerMode()) {
-            _nPrevClientX = oEvent.clientX;
-            _nPrevClientY = oEvent.clientY;
-        }
+        _nPrevClientX = oEvent.clientX;
+        _nPrevClientY = oEvent.clientY;
 
         return bChanged;
     };


### PR DESCRIPTION
Issue:
When open and close popup by 5way key press, we expect that we are in 5way mode.
Unexpected mouse move event with same position fired on every show/hide if we do 
dom.focus on animating element. And the pointer mode is still false in this case.

We have a logic that is dropping mouse move event which doesn't
actually changed position or count of event is less then 2. Logically, it should be filtered 
out in here. But, problem happens when pointer mode is false because it is only update
last position on pointer mode.

Fix:
We noticed that the center mouse move event on cursor hide is now doesn't come.
So, we removing spotlight pointer mode check from clientXYChanged. And, now It
can always cache last mouse position to compare movement.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)