### PR TITLE
ENYO-3425: Nearest neighbor compare position with first child when

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -86,8 +86,8 @@ module.exports = function (Spotlight) {
                         return true;
                     }
                     break;
-                case 'requestClearLastFocus':
-                    _oThis.setLastFocusedChild(oSender, null);
+                case 'onRequestSetLastFocusedChild':
+                    _oThis.setLastFocusedChild(oSender, oEvent.last);
                     break;
             }
         },

--- a/src/container.js
+++ b/src/container.js
@@ -86,6 +86,9 @@ module.exports = function (Spotlight) {
                         return true;
                     }
                     break;
+                case 'requestClearLastFocus':
+                    _oThis.setLastFocusedChild(oSender, null);
+                    break;
             }
         },
 
@@ -248,7 +251,7 @@ module.exports = function (Spotlight) {
     * @public
     */
     this.setLastFocusedChild = function(oSender, oChild) {
-        if (oSender.spotlightRememberFocus === false || oChild === null) {
+        if (oChild === null) {
             oSender._spotlight.lastFocusedChild = null;
             return;
         }

--- a/src/neighbor.js
+++ b/src/neighbor.js
@@ -385,8 +385,7 @@ module.exports = function (Spotlight) {
         var oRoot = oOpts && oOpts.root,
             oExtraCandidates = oOpts && oOpts.extraCandidates,
             oCandidates,
-            oBounds,
-            oLast;
+            oBounds;
 
         sDirection = sDirection.toUpperCase();
         oControl = oControl || Spotlight.getCurrent();
@@ -404,8 +403,7 @@ module.exports = function (Spotlight) {
         // If the control is container, the nearest neighbor is calculated based on the bounds
         // of last focused child of container.
         if (Spotlight.isContainer(oControl)) {
-            oLast = Spotlight.Container.getLastFocusedChild(oControl);
-            oControl = oControl.spotlightRememberFocus && oLast ? oLast : oControl;
+            oControl = Spotlight.Container.getLastFocusedChild(oControl) || oControl;
         }
 
         oBounds = oControl.getAbsoluteBounds();

--- a/src/neighbor.js
+++ b/src/neighbor.js
@@ -385,7 +385,8 @@ module.exports = function (Spotlight) {
         var oRoot = oOpts && oOpts.root,
             oExtraCandidates = oOpts && oOpts.extraCandidates,
             oCandidates,
-            oBounds;
+            oBounds,
+            oLast;
 
         sDirection = sDirection.toUpperCase();
         oControl = oControl || Spotlight.getCurrent();
@@ -403,7 +404,8 @@ module.exports = function (Spotlight) {
         // If the control is container, the nearest neighbor is calculated based on the bounds
         // of last focused child of container.
         if (Spotlight.isContainer(oControl)) {
-            oControl = Spotlight.Container.getLastFocusedChild(oControl) || oControl;
+            oLast = Spotlight.Container.getLastFocusedChild(oControl);
+            oControl = oControl.spotlightRememberFocus && oLast ? oLast : oControl;
         }
 
         oBounds = oControl.getAbsoluteBounds();


### PR DESCRIPTION
spotlightRememberFocus is false

The getNearestNeighbor is compares position between container itself and
outside control. But, when focus is moving out from container it is
expecting compare position with its last focused child not container
itself. When container have spotlightRememberFocus false, we reset last
focus to null. This behavior affect getNearestNeighbor logic and
getLastFocusedChild return first child.

Revert previous change that is supporting spotlightRememberFocus false
on explicit spot. But, we support same feature on popup and notification
by adding explicit event that is reset last focused child on container
and calling it on hide.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)