### PR TITLE
ENYO-3430: Preserve acceleration when container control have

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -547,11 +547,14 @@ var Spotlight = module.exports = new function () {
             if (oControl) {
                 _oThis.spot(oControl, {direction: sDirection});
             } else {
-                if (_oThis.Accelerator.isAccelerating()) {
+                var oParent = _oThis.getParent(),
+                    oCurrent = _oThis.getCurrent();
+                if (_oThis.Accelerator.isAccelerating() && oParent && !oParent.spotlightPreserveAcceleration) {
                     _oThis.Accelerator.cancel();
+                    if (oCurrent && oCurrent.spotlight === 'container') {
+                        _spotLastControl({focusType: '5-way bounce'});
+                    }
                 } else {
-                    var oParent = _oThis.getParent();
-
                     // Reached the end of spottable world
                     if (!oParent || oParent.spotlightModal) {
                         _spotLastControl({focusType: '5-way bounce'});


### PR DESCRIPTION
spotlightPreserveAcceleration property as true.

When spotlight container control have only one spottable item,
just like ExpandableListItem family, it cancel 5way key acceleration.

We add a property which can be given on container control that
is skipping acceleration cancel logic.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)