### PR TITLE
PLAT-24842:Components not selectable after switching between the tabs…

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -885,10 +885,11 @@ var Spotlight = module.exports = new function () {
                     }
                     break;
                 case 'mousedown':
-                case 'touchstart':
                     return this.onMouseDown(oEvent);
                 case 'mouseup':
                     return this.onMouseUp(oEvent);
+                case 'touchstart':
+                    return this.onMouseMove(oEvent);
                 case 'click':
                 case 'tap':
                 case 'ontap':

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -885,6 +885,7 @@ var Spotlight = module.exports = new function () {
                     }
                     break;
                 case 'mousedown':
+                case 'touchstart':
                     return this.onMouseDown(oEvent);
                 case 'mouseup':
                     return this.onMouseUp(oEvent);


### PR DESCRIPTION
PLAT-24842:  Moonstone component test - Components not selectable after switching between the tabs or apps

Issue: On touch devices switching between the tabs or apps component gets a default focus (spotlight). After this touch will not work on any other component until the view is scrolled or moved.
Cause: On non-webOs devices pointer mode was set to false after blur, prevents the event bubbling. So tap or any action will not work
Fix:  'touchstart' case was included in onEvent function, which eventually calls onMouseMove which sets the pointer.

Enyo-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)
