### PR TITLE
ENYO-3450: Only skip unhighlight on unspot and dispatch blur event.

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1724,8 +1724,8 @@ var Spotlight = module.exports = new function () {
             return false;
         }
 
-        if (this.hasCurrent() && _bFocusOnScreen) {
-            _unhighlight(_oCurrent);
+        if (this.hasCurrent()) {
+            _bFocusOnScreen && _unhighlight(_oCurrent);
             _oLastMouseMoveTarget = null;
             _dispatchEvent('onSpotlightBlur', {next: oNext}, _oCurrent);
             _observeDisappearance(false, _oCurrent);


### PR DESCRIPTION
Issue:
We skip highlight but dispatch onSpotlightFocus on setCurrent while
muted. But, we skip dispatch onSpotlightBlur on unspot when there is no
highlight focus on screen by checking _bFocusOnScreen variable. This
leads missmatch between event.

Fix:
We skip only unhighlight from unspot when _bFocusOnScreen is false. And
do dispatch onSpotlightBlur event.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)