### PR TITLE
ENYO-3451: Dispatch onSpotlightBlur on disappear

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -355,12 +355,15 @@ var Spotlight = module.exports = new function () {
                 // Find spottable parent or first spottable in the app as a fallback
                 oControl = _oThis.getParent() || _oThis.getFirstChild(_oRoot);
                 if (!oControl) {
-                    _unhighlight(_oLastControl);
-                    _oLastControl = null;
-
+                    _unhighlight(_oCurrent);
+                    _dispatchEvent('onSpotlightBlur', {}, _oCurrent);
                     _observeDisappearance(false, _oCurrent);
+                    if (_oCurrent.hasNode()) {
+                        _oCurrent.node.blur();
+                    }
                     // NULL CASE :(, just like when no spottable children found on init
                     _oCurrent = null;
+                    _oLastControl = null;
                     return;
                 }
             }


### PR DESCRIPTION
Issue:
We dont dispatch onSpotlightBlur on onDisappear routine. That is because
we doesn't have any usecases for this case. But, store demo app recently
reported an issue regarding to this because they need to recover some
state on blur event.

Fix:
We dispatch onSpotlightBlur on disappear, so that any control that is
unhighlight focus can get event.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)