### PR TITLE
ENYO-3467: Block _spotNearestToPointer while LightPanel is in transition

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -179,6 +179,15 @@ var Spotlight = module.exports = new function () {
         _bPaused = false,
 
         /**
+        * When true, recover focus on key press while current is not focusable.
+        *
+        * @type {Boolean}
+        * @default true
+        * @private
+        */
+        _bRecoverNoFocus = true,
+
+        /**
         * Contains the control specified in `defaultSpotlightDisappear` property of
         * `_oCurrent`.
         * @type {Object}
@@ -1201,7 +1210,10 @@ var Spotlight = module.exports = new function () {
                 // Or spot last 5-way control, only if there's not already focus on screen
                 (bWasPointerMode && !_oLastMouseMoveTarget && !this.isFrozen())) {
 
-                _spotNearestToPointer(oEvent);
+                if (this.isRecoverNoFocus()) {
+                    _spotNearestToPointer(oEvent);
+                }
+
                 _bSuppressSelectOnNextKeyUp = oEvent.keyCode == 13;
                 return false;
             }
@@ -1879,6 +1891,26 @@ var Spotlight = module.exports = new function () {
     */
     this.isPaused = function() {
         return _bPaused;
+    };
+
+    /**
+    * Sets recover nearest focus on key press mode.
+    *
+    * @param {Boolean} bFlag - `true` if Spotlight is currently recover no focus; otherwise, `false`.
+    * @private
+    */
+    this.setRecoverNoFocus = function(bFlag) {
+        _bRecoverNoFocus = bFlag;
+    };
+
+    /**
+    * Determines whether recover focus at nearest to pointer on key press.
+    *
+    * @return {Boolean} `true` if Spotlight is currently recover no focus; otherwise, `false`.
+    * @private
+    */
+    this.isRecoverNoFocus = function() {
+        return _bRecoverNoFocus;
     };
 
     /**


### PR DESCRIPTION
Issue:
LightPanel pause spotlight on preTransition and resume spotlight on
postTransition. And give default focus on active panel in async call.
Spotlight recover focus when pressing 5way key while current focus is
not spottable or when no focus under pointer in pointer mode.
This can lead unexpected focus jump to first control in screen if press
repeated 5way key while panel transitioning.

Fix:
We add an API that blocking _spotNearestToPointer. And, block this
behavior between resume and default spot.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)
