### PR TITLE
ENYO-3490 : Add condition when audio guidance is fire in spotlightFocused

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1348,9 +1348,14 @@ var Spotlight = module.exports = new function () {
         // transfer focus to its internal input.
         if (options.accessibility && !this.getPointerMode()) {
             if (c && !c.accessibilityDisabled && c.tag != 'label') {
-                c.focus();
-            }
-            else if (oEvent.previous) {
+                if (c == oEvent.previous) {
+                    if (oEvent.focusType == 'default') {
+                        c.focus();
+                    }
+                } else {
+                    c.focus();
+                }
+            } else if (oEvent.previous) {
                 oEvent.previous.blur();
             }
         }


### PR DESCRIPTION
Issue
: Read button again despite it is already focused

Fix
: Blocking audio guidance when current focus is same to previous. (But when window blur & focus case, same button focused but have to fire. So I insert check condition for this)

Enyo-DCO-1.1-Signed-off-by: Changgi Lee changgi.lee@lge.com
