### PR TITLE
ENYO-3467: Adding skipLastFocusUpdate property that skip update last

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -237,7 +237,11 @@ module.exports = function (Spotlight) {
     this.getLastFocusedChild = function(oSender) {
         oSender._spotlight = oSender._spotlight || {};
         if (!oSender._spotlight.lastFocusedChild || !Spotlight.isSpottable(oSender._spotlight.lastFocusedChild)) {
-            oSender._spotlight.lastFocusedChild = Spotlight.getChildren(oSender)[0];
+            var oChild = Spotlight.getFirstChild(oSender);
+            if (oChild && oChild.skipLastFocusUpdate) {
+                return null;
+            }
+            oSender._spotlight.lastFocusedChild = oChild;
         }
         return oSender._spotlight.lastFocusedChild;
     };
@@ -257,6 +261,9 @@ module.exports = function (Spotlight) {
         }
         if (!Spotlight.isSpottable(oChild)) {
             oChild = Spotlight.getFirstChild(oChild);
+        }
+        if (oChild && oChild.skipLastFocusUpdate) {
+            return;
         }
         if (oChild) {
             oSender._spotlight = oSender._spotlight || {};


### PR DESCRIPTION
focused child

Issue:
When placeholder (spotlight dummy) get focused, it update last focused
child to dummy. And when container control get focused, it will give
focus to dummy.

Fix:
Add a property called skipLastFocusUpdate to placeholder control to let
container know it should not affect last focused child.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)
