### PR TITLE
ENYO-3490: Skip read when restore focus on same data list item

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -1348,9 +1348,10 @@ var Spotlight = module.exports = new function () {
         // transfer focus to its internal input.
         if (options.accessibility && !this.getPointerMode()) {
             if (c && !c.accessibilityDisabled && c.tag != 'label') {
-                c.focus();
-            }
-            else if (oEvent.previous) {
+                if (!oEvent.skipRead && !(c == oEvent.previous && oEvent.focusType === '5-way bounce')) {
+                    c.focus();
+                }
+            } else if (oEvent.previous) {
                 oEvent.previous.blur();
             }
         }


### PR DESCRIPTION
Issue:
When data list update its list while item focused, data list remember
last focused item index on remove and restore it on add. When restore
focus, item content can be the same or different because it find item
based on index not content. When item restore focus on the item that
have the same content, TTS will read content. Problem happens when
update list frequently because it will read everytime it update.

Fix:
We add a property like 'primaryKey' just like collection, and skip read
when the key is the same.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)
