### PR TITLE
ENYO-3732: Restrict dom node's blur call

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -866,6 +866,8 @@ var Spotlight = module.exports = new function () {
                 case 'blur':
                     if (oEvent.target === window) {
                         // Whenever app goes to background, unspot focus
+                        var t = this.getCurrent() && this.getCurrent().hasNode();
+                        if(t) t.blur && t.blur();
                         this.unspot();
                         this.setPointerMode(false);
 
@@ -1741,9 +1743,6 @@ var Spotlight = module.exports = new function () {
             _oLastMouseMoveTarget = null;
             _dispatchEvent('onSpotlightBlur', {next: oNext}, _oCurrent);
             _observeDisappearance(false, _oCurrent);
-            if (_oCurrent.hasNode()) {
-                _oCurrent.node.blur();
-            }
             _oCurrent = null;
             return true;
         }


### PR DESCRIPTION
Restrict blur call for prevent lost active element when 5 way bounce happen.

Enyo-DCO-1.1-Signed-off-by: Changgi Lee changgi.lee@lge.com