### PR TITLE
ENYO-3732: Prevent unexpected blur during key navigation

### DIFF
--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -866,11 +866,11 @@ var Spotlight = module.exports = new function () {
                 case 'blur':
                     if (oEvent.target === window) {
                         // Whenever app goes to background, unspot focus
-			var c = this.getCurrent();
+                        var c = this.getCurrent();
                         var t = c && c.hasNode();
                         if (t) {
-				t.blur && t.blur();
-			}
+                            t.blur && t.blur();
+                        }
                         this.unspot();
                         this.setPointerMode(false);
 

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -866,6 +866,8 @@ var Spotlight = module.exports = new function () {
                 case 'blur':
                     if (oEvent.target === window) {
                         // Whenever app goes to background, unspot focus
+                        var t = this.getCurrent() && this.getCurrent().hasNode();
+                        if(t) t.blur && t.blur();
                         this.unspot();
                         this.setPointerMode(false);
 
@@ -1741,9 +1743,6 @@ var Spotlight = module.exports = new function () {
             _oLastMouseMoveTarget = null;
             _dispatchEvent('onSpotlightBlur', {next: oNext}, _oCurrent);
             _observeDisappearance(false, _oCurrent);
-            if (_oCurrent.hasNode()) {
-                _oCurrent.node.blur();
-            }
             _oCurrent = null;
             return true;
         }

--- a/src/spotlight.js
+++ b/src/spotlight.js
@@ -866,8 +866,11 @@ var Spotlight = module.exports = new function () {
                 case 'blur':
                     if (oEvent.target === window) {
                         // Whenever app goes to background, unspot focus
-                        var t = this.getCurrent() && this.getCurrent().hasNode();
-                        if(t) t.blur && t.blur();
+			var c = this.getCurrent();
+                        var t = c && c.hasNode();
+                        if (t) {
+				t.blur && t.blur();
+			}
                         this.unspot();
                         this.setPointerMode(false);
 


### PR DESCRIPTION
When focus try to escape container, unexpected blur is happen even still stay same container.

Enyo-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>